### PR TITLE
feat(profiles): add create, rename, and delete profile methods

### DIFF
--- a/src/eero/api/profiles.py
+++ b/src/eero/api/profiles.py
@@ -361,9 +361,7 @@ class ProfilesAPI(AuthenticatedAPI):
             json={"name": name},
         )
 
-    async def rename_profile(
-        self, network_id: str, profile_id: str, name: str
-    ) -> Dict[str, Any]:
+    async def rename_profile(self, network_id: str, profile_id: str, name: str) -> Dict[str, Any]:
         """Rename an existing profile - returns raw Eero API response.
 
         Args:

--- a/src/eero/api/profiles.py
+++ b/src/eero/api/profiles.py
@@ -332,3 +332,87 @@ class ProfilesAPI(AuthenticatedAPI):
             auth_token=auth_token,
             json={"blocked_applications": applications},
         )
+
+    async def create_profile(self, network_id: str, name: str) -> Dict[str, Any]:
+        """Create a new profile on the network - returns raw Eero API response.
+
+        Args:
+            network_id: ID of the network to create the profile on
+            name: Name for the new profile
+
+        Returns:
+            Raw API response: {"meta": {...}, "data": {...}}
+            The data field contains the full profile object including
+            the assigned URL/ID.
+
+        Raises:
+            EeroAuthenticationException: If not authenticated
+            EeroAPIException: If the API returns an error
+        """
+        auth_token = await self._auth_api.get_auth_token()
+        if not auth_token:
+            raise EeroAuthenticationException("Not authenticated")
+
+        _LOGGER.debug("Creating profile '%s' in network %s", name, network_id)
+
+        return await self.post(
+            f"networks/{network_id}/profiles",
+            auth_token=auth_token,
+            json={"name": name},
+        )
+
+    async def rename_profile(
+        self, network_id: str, profile_id: str, name: str
+    ) -> Dict[str, Any]:
+        """Rename an existing profile - returns raw Eero API response.
+
+        Args:
+            network_id: ID of the network the profile belongs to
+            profile_id: ID of the profile to rename
+            name: New name for the profile
+
+        Returns:
+            Raw API response: {"meta": {...}, "data": {...}}
+
+        Raises:
+            EeroAuthenticationException: If not authenticated
+            EeroAPIException: If the API returns an error
+        """
+        auth_token = await self._auth_api.get_auth_token()
+        if not auth_token:
+            raise EeroAuthenticationException("Not authenticated")
+
+        _LOGGER.debug("Renaming profile %s to '%s'", profile_id, name)
+
+        return await self.put(
+            f"networks/{network_id}/profiles/{profile_id}",
+            auth_token=auth_token,
+            json={"name": name},
+        )
+
+    async def delete_profile(self, network_id: str, profile_id: str) -> Dict[str, Any]:
+        """Delete a profile from the network - returns raw Eero API response.
+
+        Devices previously assigned to this profile will become unassigned.
+
+        Args:
+            network_id: ID of the network the profile belongs to
+            profile_id: ID of the profile to delete
+
+        Returns:
+            Raw API response: {"meta": {"code": 200, ...}}
+
+        Raises:
+            EeroAuthenticationException: If not authenticated
+            EeroAPIException: If the API returns an error
+        """
+        auth_token = await self._auth_api.get_auth_token()
+        if not auth_token:
+            raise EeroAuthenticationException("Not authenticated")
+
+        _LOGGER.debug("Deleting profile %s from network %s", profile_id, network_id)
+
+        return await self.delete(
+            f"networks/{network_id}/profiles/{profile_id}",
+            auth_token=auth_token,
+        )

--- a/src/eero/client.py
+++ b/src/eero/client.py
@@ -635,9 +635,7 @@ class EeroClient:
         if cache_key in self._cache.get("profiles", {}):
             del self._cache["profiles"][cache_key]
 
-    async def create_profile(
-        self, name: str, network_id: Optional[str] = None
-    ) -> Dict[str, Any]:
+    async def create_profile(self, name: str, network_id: Optional[str] = None) -> Dict[str, Any]:
         """Create a new profile on the network - returns raw Eero API response.
 
         Args:

--- a/src/eero/client.py
+++ b/src/eero/client.py
@@ -629,6 +629,75 @@ class EeroClient:
         if cache_key in self._cache.get("profiles", {}):
             del self._cache["profiles"][cache_key]
 
+    def _invalidate_profiles_list_cache(self, network_id: str) -> None:
+        """Invalidate the profiles list cache for a network."""
+        cache_key = f"{network_id}_profiles"
+        if cache_key in self._cache.get("profiles", {}):
+            del self._cache["profiles"][cache_key]
+
+    async def create_profile(
+        self, name: str, network_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Create a new profile on the network - returns raw Eero API response.
+
+        Args:
+            name: Name for the new profile
+            network_id: ID of the network (uses preferred if None)
+
+        Returns:
+            Raw API response: {"meta": {...}, "data": {...}}
+        """
+        network_id = await self._ensure_network_id(network_id)
+
+        response = await self._api.profiles.create_profile(network_id, name)
+
+        self._invalidate_profiles_list_cache(network_id)
+
+        return response
+
+    async def rename_profile(
+        self, profile_id: str, name: str, network_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Rename an existing profile - returns raw Eero API response.
+
+        Args:
+            profile_id: ID of the profile to rename
+            name: New name for the profile
+            network_id: ID of the network (uses preferred if None)
+
+        Returns:
+            Raw API response: {"meta": {...}, "data": {...}}
+        """
+        network_id = await self._ensure_network_id(network_id)
+
+        response = await self._api.profiles.rename_profile(network_id, profile_id, name)
+
+        self._invalidate_profile_cache(network_id, profile_id)
+
+        return response
+
+    async def delete_profile(
+        self, profile_id: str, network_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Delete a profile from the network - returns raw Eero API response.
+
+        Devices previously assigned to this profile will become unassigned.
+
+        Args:
+            profile_id: ID of the profile to delete
+            network_id: ID of the network (uses preferred if None)
+
+        Returns:
+            Raw API response: {"meta": {"code": 200, ...}}
+        """
+        network_id = await self._ensure_network_id(network_id)
+
+        response = await self._api.profiles.delete_profile(network_id, profile_id)
+
+        self._invalidate_profile_cache(network_id, profile_id)
+
+        return response
+
     # ==================== Guest Network ====================
 
     async def set_guest_network(

--- a/tests/api/test_profiles.py
+++ b/tests/api/test_profiles.py
@@ -348,3 +348,147 @@ class TestProfilesAPIDeviceManagement:
             await profiles_api.set_profile_devices(
                 "network_123", "profile_001", ["/2.2/networks/net123/devices/dev001"]
             )
+
+
+class TestProfilesAPICreateProfile:
+    """Tests for create_profile method."""
+
+    @pytest.fixture
+    def profiles_api(self, mock_session):
+        """Create a ProfilesAPI with mocked auth."""
+        auth_api = MagicMock()
+        auth_api.session = mock_session
+        auth_api.get_auth_token = AsyncMock(return_value="auth_token")
+        return ProfilesAPI(auth_api)
+
+    @pytest.mark.asyncio
+    async def test_create_profile_returns_raw_response(self, profiles_api, mock_session):
+        """Test creating a profile returns raw response with profile data."""
+        profile_data = {
+            "url": "/2.2/networks/network_123/profiles/new_profile_001",
+            "name": "Kids",
+            "paused": False,
+            "devices": [],
+        }
+        expected_response = api_success_response(profile_data)
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        result = await profiles_api.create_profile("network_123", "Kids")
+
+        assert "meta" in result
+        assert "data" in result
+        assert result["data"]["name"] == "Kids"
+        call_args = mock_session.request.call_args
+        assert call_args.kwargs["json"] == {"name": "Kids"}
+
+    @pytest.mark.asyncio
+    async def test_create_profile_uses_post_method(self, profiles_api, mock_session):
+        """Test create_profile sends a POST request."""
+        expected_response = api_success_response({"name": "Test"})
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        await profiles_api.create_profile("network_123", "Test")
+
+        call_args = mock_session.request.call_args
+        assert call_args.args[0] == "POST"
+
+    @pytest.mark.asyncio
+    async def test_create_profile_not_authenticated(self, profiles_api):
+        """Test create_profile raises when not authenticated."""
+        profiles_api._auth_api.get_auth_token = AsyncMock(return_value=None)
+
+        with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
+            await profiles_api.create_profile("network_123", "Kids")
+
+
+class TestProfilesAPIRenameProfile:
+    """Tests for rename_profile method."""
+
+    @pytest.fixture
+    def profiles_api(self, mock_session):
+        """Create a ProfilesAPI with mocked auth."""
+        auth_api = MagicMock()
+        auth_api.session = mock_session
+        auth_api.get_auth_token = AsyncMock(return_value="auth_token")
+        return ProfilesAPI(auth_api)
+
+    @pytest.mark.asyncio
+    async def test_rename_profile_returns_raw_response(self, profiles_api, mock_session):
+        """Test renaming a profile returns raw response."""
+        profile_data = {"name": "New Name", "paused": False}
+        expected_response = api_success_response(profile_data)
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        result = await profiles_api.rename_profile("network_123", "profile_001", "New Name")
+
+        assert "meta" in result
+        assert result["data"]["name"] == "New Name"
+        call_args = mock_session.request.call_args
+        assert call_args.kwargs["json"] == {"name": "New Name"}
+
+    @pytest.mark.asyncio
+    async def test_rename_profile_uses_put_method(self, profiles_api, mock_session):
+        """Test rename_profile sends a PUT request."""
+        expected_response = api_success_response({"name": "Renamed"})
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        await profiles_api.rename_profile("network_123", "profile_001", "Renamed")
+
+        call_args = mock_session.request.call_args
+        assert call_args.args[0] == "PUT"
+
+    @pytest.mark.asyncio
+    async def test_rename_profile_not_authenticated(self, profiles_api):
+        """Test rename_profile raises when not authenticated."""
+        profiles_api._auth_api.get_auth_token = AsyncMock(return_value=None)
+
+        with pytest.raises(EeroAuthenticationException):
+            await profiles_api.rename_profile("network_123", "profile_001", "New Name")
+
+
+class TestProfilesAPIDeleteProfile:
+    """Tests for delete_profile method."""
+
+    @pytest.fixture
+    def profiles_api(self, mock_session):
+        """Create a ProfilesAPI with mocked auth."""
+        auth_api = MagicMock()
+        auth_api.session = mock_session
+        auth_api.get_auth_token = AsyncMock(return_value="auth_token")
+        return ProfilesAPI(auth_api)
+
+    @pytest.mark.asyncio
+    async def test_delete_profile_returns_raw_response(self, profiles_api, mock_session):
+        """Test deleting a profile returns raw response."""
+        expected_response = {"meta": {"code": 200}}
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        result = await profiles_api.delete_profile("network_123", "profile_001")
+
+        assert "meta" in result
+        assert result["meta"]["code"] == 200
+
+    @pytest.mark.asyncio
+    async def test_delete_profile_uses_delete_method(self, profiles_api, mock_session):
+        """Test delete_profile sends a DELETE request."""
+        expected_response = {"meta": {"code": 200}}
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        await profiles_api.delete_profile("network_123", "profile_001")
+
+        call_args = mock_session.request.call_args
+        assert call_args.args[0] == "DELETE"
+
+    @pytest.mark.asyncio
+    async def test_delete_profile_not_authenticated(self, profiles_api):
+        """Test delete_profile raises when not authenticated."""
+        profiles_api._auth_api.get_auth_token = AsyncMock(return_value=None)
+
+        with pytest.raises(EeroAuthenticationException):
+            await profiles_api.delete_profile("network_123", "profile_001")


### PR DESCRIPTION
## Why

The ProfilesAPI currently supports reading profiles and mutating their state (pause, devices, content filters, blocked apps) but is missing three fundamental CRUD operations: **create**, **rename**, and **delete**.

All three operations work against the eero cloud API -- I verified them against a live network:

| Operation | Method | Endpoint | Payload |
|-----------|--------|----------|---------|
| Create | POST | `/networks/{id}/profiles` | `{"name": "..."}` |
| Rename | PUT | `/networks/{id}/profiles/{pid}` | `{"name": "..."}` |
| Delete | DELETE | `/networks/{id}/profiles/{pid}` | -- |

## Changes

### `src/eero/api/profiles.py`
- `create_profile(network_id, name)` -- POST to create a new profile
- `rename_profile(network_id, profile_id, name)` -- PUT to update the name
- `delete_profile(network_id, profile_id)` -- DELETE to remove a profile

### `src/eero/client.py`
- `create_profile(name, network_id=None)` -- high-level wrapper with cache invalidation
- `rename_profile(profile_id, name, network_id=None)` -- high-level wrapper with cache invalidation
- `delete_profile(profile_id, network_id=None)` -- high-level wrapper with cache invalidation

### `tests/api/test_profiles.py`
- `TestProfilesAPICreateProfile` -- POST payload, HTTP method, auth check
- `TestProfilesAPIRenameProfile` -- PUT payload, HTTP method, auth check
- `TestProfilesAPIDeleteProfile` -- DELETE call, HTTP method, auth check

All new methods follow existing conventions: auth token validation, debug logging, docstrings with Args/Returns/Raises.