### PR TITLE
fix: route mutations to /networks/{id}/settings endpoint

### DIFF
--- a/src/eero/api/dns.py
+++ b/src/eero/api/dns.py
@@ -81,7 +81,7 @@ class DnsAPI(AuthenticatedAPI):
         )
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"dns_caching": enabled},
         )
@@ -118,7 +118,7 @@ class DnsAPI(AuthenticatedAPI):
         _LOGGER.debug("Setting custom DNS for network %s: %s", network_id, dns_servers)
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"custom_dns": dns_servers},
         )
@@ -178,7 +178,7 @@ class DnsAPI(AuthenticatedAPI):
         _LOGGER.debug("Setting DNS mode to %s for network %s", mode, network_id)
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json=payload,
         )
@@ -208,7 +208,7 @@ class DnsAPI(AuthenticatedAPI):
         )
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"ipv6_upstream": enabled},
         )

--- a/src/eero/api/networks.py
+++ b/src/eero/api/networks.py
@@ -103,7 +103,7 @@ class NetworksAPI(AuthenticatedAPI):
             payload["password"] = password
 
         return await self.put(
-            f"networks/{network_id}/guest_network",
+            f"networks/{network_id}/guestnetwork",
             auth_token=auth_token,
             json=payload,
         )

--- a/src/eero/api/networks.py
+++ b/src/eero/api/networks.py
@@ -202,7 +202,7 @@ class NetworksAPI(AuthenticatedAPI):
         _LOGGER.debug("Setting network name for %s to '%s'", network_id, name)
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"name": name},
         )

--- a/src/eero/api/security.py
+++ b/src/eero/api/security.py
@@ -84,7 +84,7 @@ class SecurityAPI(AuthenticatedAPI):
         )
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"wpa3": enabled},
         )
@@ -117,7 +117,7 @@ class SecurityAPI(AuthenticatedAPI):
         )
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"band_steering": enabled},
         )
@@ -150,7 +150,7 @@ class SecurityAPI(AuthenticatedAPI):
         )
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"upnp": enabled},
         )
@@ -180,7 +180,7 @@ class SecurityAPI(AuthenticatedAPI):
         )
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={
                 "ipv6_upstream": enabled,
@@ -216,7 +216,7 @@ class SecurityAPI(AuthenticatedAPI):
         )
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"thread": enabled},
         )
@@ -276,7 +276,7 @@ class SecurityAPI(AuthenticatedAPI):
         _LOGGER.debug("Configuring security for network %s: %s", network_id, payload)
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json=payload,
         )

--- a/src/eero/api/sqm.py
+++ b/src/eero/api/sqm.py
@@ -81,9 +81,9 @@ class SqmAPI(AuthenticatedAPI):
         )
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
-            json={"sqm": {"enabled": enabled}},
+            json={"sqm": enabled},
         )
 
     async def set_sqm_bandwidth(
@@ -126,7 +126,7 @@ class SqmAPI(AuthenticatedAPI):
         )
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"sqm": sqm_payload},
         )
@@ -168,7 +168,7 @@ class SqmAPI(AuthenticatedAPI):
         _LOGGER.debug("Configuring SQM for network %s: %s", network_id, sqm_payload)
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"sqm": sqm_payload},
         )
@@ -189,7 +189,7 @@ class SqmAPI(AuthenticatedAPI):
         _LOGGER.debug("Setting SQM to auto mode for network %s", network_id)
 
         return await self.put(
-            f"networks/{network_id}",
+            f"networks/{network_id}/settings",
             auth_token=auth_token,
             json={"sqm": {"enabled": True, "mode": "auto"}},
         )

--- a/tests/api/test_sqm.py
+++ b/tests/api/test_sqm.py
@@ -89,7 +89,7 @@ class TestSqmAPISetEnabled:
 
         assert "meta" in result
         call_args = mock_session.request.call_args
-        assert call_args.kwargs["json"] == {"sqm": {"enabled": True}}
+        assert call_args.kwargs["json"] == {"sqm": True}
 
     @pytest.mark.asyncio
     async def test_set_sqm_enabled_not_authenticated(self, sqm_api):


### PR DESCRIPTION
## Summary

Fixes #43 — several mutation methods send `PUT` to `/networks/{network_id}` which the eero cloud API accepts (HTTP 200) but **silently ignores**. The correct endpoint for network setting mutations is `/networks/{network_id}/settings`.

## Changes

### Endpoint fix (`PUT /networks/{id}` → `PUT /networks/{id}/settings`)

| File | Methods affected |
|------|-----------------|
| `security.py` | `set_wpa3`, `set_band_steering`, `set_upnp`, `set_ipv6`, `set_thread`, `configure_security` |
| `sqm.py` | `set_sqm_enabled`, `set_sqm_bandwidth`, `configure_sqm`, `set_sqm_auto` |
| `dns.py` | `set_dns_caching`, `set_custom_dns`, `set_dns_mode`, `set_ipv6_dns` |

GET endpoints remain at `/networks/{id}` (reading the network object is fine).

### SQM payload fix

`set_sqm_enabled` now sends `{"sqm": true}` (bare boolean) instead of `{"sqm": {"enabled": true}}` (nested object). The eero API ignores the nested format.

### Guest network URL fix

`networks.py`: Changed `guest_network` → `guestnetwork` (no underscore) to match the resource URL in the network response (`"guestnetwork": "/2.2/networks/{id}/guestnetwork"`).

## Verification

Tested against live eero Pro 6E hardware (2 nodes):

```
# Before fix (PUT /networks/{id}):
GET  upnp=True
PUT  {"upnp": false} → 200 OK
GET  upnp=True  ← NO CHANGE

# After fix (PUT /networks/{id}/settings):
GET  upnp=True
PUT  {"upnp": false} → 200 OK, response shows upnp=False
GET  upnp=False  ← CHANGED ✅
```

Same pattern confirmed for SQM toggle (bare boolean format).

## Tests

All 406 existing tests pass with no modifications needed (except one SQM payload assertion updated to match the new bare boolean format).