### PR TITLE
test: add endpoint URL assertions for all mutation methods

### DIFF
--- a/src/eero/api/sqm.py
+++ b/src/eero/api/sqm.py
@@ -125,6 +125,9 @@ class SqmAPI(AuthenticatedAPI):
             download_mbps,
         )
 
+        # TODO: Verify whether bandwidth payload should be flattened (e.g. {"sqm": true,
+        # "upload_bandwidth": N}) rather than nested ({"sqm": {...}}) — pending live API
+        # verification against the /settings endpoint.
         return await self.put(
             f"networks/{network_id}/settings",
             auth_token=auth_token,
@@ -167,6 +170,9 @@ class SqmAPI(AuthenticatedAPI):
 
         _LOGGER.debug("Configuring SQM for network %s: %s", network_id, sqm_payload)
 
+        # TODO: Verify whether combined enable+bandwidth payload should be flattened rather
+        # than nested ({"sqm": {...}}) — pending live API verification against the /settings
+        # endpoint.
         return await self.put(
             f"networks/{network_id}/settings",
             auth_token=auth_token,
@@ -188,6 +194,9 @@ class SqmAPI(AuthenticatedAPI):
 
         _LOGGER.debug("Setting SQM to auto mode for network %s", network_id)
 
+        # TODO: Verify whether auto-mode payload should be flattened (e.g. {"sqm": true,
+        # "mode": "auto"}) rather than nested ({"sqm": {"enabled": true, "mode": "auto"}}) —
+        # pending live API verification against the /settings endpoint.
         return await self.put(
             f"networks/{network_id}/settings",
             auth_token=auth_token,

--- a/tests/api/test_dns.py
+++ b/tests/api/test_dns.py
@@ -89,6 +89,18 @@ class TestDnsAPISetCaching:
         assert call_args.kwargs["json"] == {"dns_caching": True}
 
     @pytest.mark.asyncio
+    async def test_set_dns_caching_targets_settings_endpoint(self, dns_api, mock_session):
+        """Test set_dns_caching sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await dns_api.set_dns_caching("network_123", True)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
+
+    @pytest.mark.asyncio
     async def test_set_dns_caching_not_authenticated(self, dns_api):
         """Test set_dns_caching raises when not authenticated."""
         dns_api._auth_api.get_auth_token = AsyncMock(return_value=None)
@@ -131,6 +143,18 @@ class TestDnsAPISetCustomDNS:
         assert "meta" in result
         call_args = mock_session.request.call_args
         assert call_args.kwargs["json"] == {"custom_dns": ["8.8.8.8", "8.8.4.4"]}
+
+    @pytest.mark.asyncio
+    async def test_set_custom_dns_targets_settings_endpoint(self, dns_api, mock_session):
+        """Test set_custom_dns sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await dns_api.set_custom_dns("network_123", ["8.8.8.8"])
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
 
     @pytest.mark.asyncio
     async def test_set_custom_dns_not_authenticated(self, dns_api):
@@ -223,6 +247,18 @@ class TestDnsAPISetMode:
         assert "meta" in result
 
     @pytest.mark.asyncio
+    async def test_set_dns_mode_targets_settings_endpoint(self, dns_api, mock_session):
+        """Test set_dns_mode sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await dns_api.set_dns_mode("network_123", "google")
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
+
+    @pytest.mark.asyncio
     async def test_set_dns_mode_not_authenticated(self, dns_api):
         """Test set_dns_mode raises when not authenticated."""
         dns_api._auth_api.get_auth_token = AsyncMock(return_value=None)
@@ -253,6 +289,18 @@ class TestDnsAPISetIPv6:
         assert "meta" in result
         call_args = mock_session.request.call_args
         assert call_args.kwargs["json"] == {"ipv6_upstream": True}
+
+    @pytest.mark.asyncio
+    async def test_set_ipv6_dns_targets_settings_endpoint(self, dns_api, mock_session):
+        """Test set_ipv6_dns sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await dns_api.set_ipv6_dns("network_123", True)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
 
     @pytest.mark.asyncio
     async def test_set_ipv6_dns_not_authenticated(self, dns_api):

--- a/tests/api/test_networks.py
+++ b/tests/api/test_networks.py
@@ -157,7 +157,9 @@ class TestNetworksAPIGuestNetwork:
         assert payload["password"] == "securepass123"
 
     @pytest.mark.asyncio
-    async def test_set_guest_network_targets_guestnetwork_endpoint(self, networks_api, mock_session):
+    async def test_set_guest_network_targets_guestnetwork_endpoint(
+        self, networks_api, mock_session
+    ):
         """Test set_guest_network uses guestnetwork endpoint (not guest_network)."""
         expected_response = {"meta": {"code": 200}, "data": {}}
         mock_response = create_mock_response(200, expected_response)

--- a/tests/api/test_networks.py
+++ b/tests/api/test_networks.py
@@ -156,6 +156,20 @@ class TestNetworksAPIGuestNetwork:
         assert payload["name"] == "My Guest Network"
         assert payload["password"] == "securepass123"
 
+    @pytest.mark.asyncio
+    async def test_set_guest_network_targets_guestnetwork_endpoint(self, networks_api, mock_session):
+        """Test set_guest_network uses guestnetwork endpoint (not guest_network)."""
+        expected_response = {"meta": {"code": 200}, "data": {}}
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        await networks_api.set_guest_network("network_123", enabled=True)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "guestnetwork" in url
+        assert "guest_network" not in url
+
 
 class TestNetworksAPISpeedTest:
     """Tests for speed test functionality."""
@@ -281,3 +295,16 @@ class TestNetworksAPISetName:
 
         call_args = mock_session.request.call_args
         assert call_args.kwargs["json"] == {"name": "My Network"}
+
+    @pytest.mark.asyncio
+    async def test_set_network_name_targets_settings_endpoint(self, networks_api, mock_session):
+        """Test set_network_name sends request to /settings endpoint."""
+        expected_response = {"meta": {"code": 200}, "data": {}}
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        await networks_api.set_network_name("network_123", "My Network")
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url

--- a/tests/api/test_security.py
+++ b/tests/api/test_security.py
@@ -84,6 +84,18 @@ class TestSecurityAPISetWPA3:
         assert call_args.kwargs["json"] == {"wpa3": True}
 
     @pytest.mark.asyncio
+    async def test_set_wpa3_targets_settings_endpoint(self, security_api, mock_session):
+        """Test set_wpa3 sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await security_api.set_wpa3("network_123", True)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
+
+    @pytest.mark.asyncio
     async def test_set_wpa3_not_authenticated(self, security_api):
         """Test set_wpa3 raises when not authenticated."""
         security_api._auth_api.get_auth_token = AsyncMock(return_value=None)
@@ -113,6 +125,18 @@ class TestSecurityAPISetBandSteering:
 
         assert "meta" in result
 
+    @pytest.mark.asyncio
+    async def test_set_band_steering_targets_settings_endpoint(self, security_api, mock_session):
+        """Test set_band_steering sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await security_api.set_band_steering("network_123", True)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
+
 
 class TestSecurityAPISetUPnP:
     """Tests for set_upnp method."""
@@ -135,6 +159,102 @@ class TestSecurityAPISetUPnP:
 
         assert "meta" in result
 
+    @pytest.mark.asyncio
+    async def test_set_upnp_targets_settings_endpoint(self, security_api, mock_session):
+        """Test set_upnp sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await security_api.set_upnp("network_123", True)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
+
+
+class TestSecurityAPISetIPv6:
+    """Tests for set_ipv6 method."""
+
+    @pytest.fixture
+    def security_api(self, mock_session):
+        """Create a SecurityAPI with mocked auth."""
+        auth_api = MagicMock()
+        auth_api.session = mock_session
+        auth_api.get_auth_token = AsyncMock(return_value="auth_token")
+        return SecurityAPI(auth_api)
+
+    @pytest.mark.asyncio
+    async def test_set_ipv6_returns_raw_response(self, security_api, mock_session):
+        """Test setting IPv6 returns raw response."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        result = await security_api.set_ipv6("network_123", True)
+
+        assert "meta" in result
+
+    @pytest.mark.asyncio
+    async def test_set_ipv6_targets_settings_endpoint(self, security_api, mock_session):
+        """Test set_ipv6 sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await security_api.set_ipv6("network_123", True)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
+
+    @pytest.mark.asyncio
+    async def test_set_ipv6_not_authenticated(self, security_api):
+        """Test set_ipv6 raises when not authenticated."""
+        security_api._auth_api.get_auth_token = AsyncMock(return_value=None)
+
+        with pytest.raises(EeroAuthenticationException):
+            await security_api.set_ipv6("network_123", True)
+
+
+class TestSecurityAPISetThread:
+    """Tests for set_thread method."""
+
+    @pytest.fixture
+    def security_api(self, mock_session):
+        """Create a SecurityAPI with mocked auth."""
+        auth_api = MagicMock()
+        auth_api.session = mock_session
+        auth_api.get_auth_token = AsyncMock(return_value="auth_token")
+        return SecurityAPI(auth_api)
+
+    @pytest.mark.asyncio
+    async def test_set_thread_returns_raw_response(self, security_api, mock_session):
+        """Test setting Thread returns raw response."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        result = await security_api.set_thread("network_123", True)
+
+        assert "meta" in result
+
+    @pytest.mark.asyncio
+    async def test_set_thread_targets_settings_endpoint(self, security_api, mock_session):
+        """Test set_thread sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await security_api.set_thread("network_123", True)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
+
+    @pytest.mark.asyncio
+    async def test_set_thread_not_authenticated(self, security_api):
+        """Test set_thread raises when not authenticated."""
+        security_api._auth_api.get_auth_token = AsyncMock(return_value=None)
+
+        with pytest.raises(EeroAuthenticationException):
+            await security_api.set_thread("network_123", True)
+
 
 class TestSecurityAPIConfigure:
     """Tests for configure_security method."""
@@ -156,6 +276,18 @@ class TestSecurityAPIConfigure:
         result = await security_api.configure_security("network_123", wpa3=True, upnp=False)
 
         assert "meta" in result
+
+    @pytest.mark.asyncio
+    async def test_configure_security_targets_settings_endpoint(self, security_api, mock_session):
+        """Test configure_security sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await security_api.configure_security("network_123", wpa3=True, upnp=False)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
 
     @pytest.mark.asyncio
     async def test_configure_security_not_authenticated(self, security_api):

--- a/tests/api/test_sqm.py
+++ b/tests/api/test_sqm.py
@@ -92,6 +92,18 @@ class TestSqmAPISetEnabled:
         assert call_args.kwargs["json"] == {"sqm": True}
 
     @pytest.mark.asyncio
+    async def test_set_sqm_enabled_targets_settings_endpoint(self, sqm_api, mock_session):
+        """Test set_sqm_enabled sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await sqm_api.set_sqm_enabled("network_123", True)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
+
+    @pytest.mark.asyncio
     async def test_set_sqm_enabled_not_authenticated(self, sqm_api):
         """Test set_sqm_enabled raises when not authenticated."""
         sqm_api._auth_api.get_auth_token = AsyncMock(return_value=None)
@@ -140,6 +152,18 @@ class TestSqmAPISetBandwidth:
         assert payload["sqm"]["download_bandwidth"] == 500
 
     @pytest.mark.asyncio
+    async def test_set_sqm_bandwidth_targets_settings_endpoint(self, sqm_api, mock_session):
+        """Test set_sqm_bandwidth sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await sqm_api.set_sqm_bandwidth("network_123", upload_mbps=50)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
+
+    @pytest.mark.asyncio
     async def test_set_sqm_bandwidth_not_authenticated(self, sqm_api):
         """Test set_sqm_bandwidth raises when not authenticated."""
         sqm_api._auth_api.get_auth_token = AsyncMock(return_value=None)
@@ -178,6 +202,18 @@ class TestSqmAPIConfigure:
         assert payload["sqm"]["enabled"] is True
 
     @pytest.mark.asyncio
+    async def test_configure_sqm_targets_settings_endpoint(self, sqm_api, mock_session):
+        """Test configure_sqm sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await sqm_api.configure_sqm("network_123", enabled=True, upload_mbps=100, download_mbps=500)
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
+
+    @pytest.mark.asyncio
     async def test_configure_sqm_not_authenticated(self, sqm_api):
         """Test configure_sqm raises when not authenticated."""
         sqm_api._auth_api.get_auth_token = AsyncMock(return_value=None)
@@ -209,6 +245,18 @@ class TestSqmAPISetAuto:
         call_args = mock_session.request.call_args
         payload = call_args.kwargs["json"]
         assert payload["sqm"]["mode"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_set_sqm_auto_targets_settings_endpoint(self, sqm_api, mock_session):
+        """Test set_sqm_auto sends request to /settings endpoint."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await sqm_api.set_sqm_auto("network_123")
+
+        call_args = mock_session.request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url", "")
+        assert "networks/network_123/settings" in url
 
     @pytest.mark.asyncio
     async def test_set_sqm_auto_not_authenticated(self, sqm_api):


### PR DESCRIPTION
## Summary

Follow-up to #44 — adds the testing gap that allowed the silently-ignored mutations bug (#43) to exist undetected.

- **16 new endpoint URL assertion tests** across `test_security.py`, `test_sqm.py`, `test_dns.py`, and `test_networks.py`
- **3 TODO comments** on SQM methods where nested payload format needs live API verification (`set_sqm_bandwidth`, `configure_sqm`, `set_sqm_auto`)

Every mutation method now has a test verifying it targets the correct endpoint URL, preventing this entire bug class from recurring.

## Changes

| File | New tests |
|------|-----------|
| `test_security.py` | 6 URL assertions + new `TestSecurityAPISetIPv6` and `TestSecurityAPISetThread` classes |
| `test_sqm.py` | 4 URL assertions |
| `test_dns.py` | 4 URL assertions |
| `test_networks.py` | 2 URL assertions (including `guestnetwork` not `guest_network` check) |
| `sqm.py` | 3 TODO comments (no logic changes) |

## Test plan

- [x] All 435 tests pass locally
- [x] No source logic changes — only test additions and TODO comments
- [x] Rebased cleanly on top of merged PR #44 (v4.1.2)

Ref: #43