### PR TITLE
fix(profiles): invalidate profiles list cache on rename and delete

### DIFF
--- a/src/eero/client.py
+++ b/src/eero/client.py
@@ -671,6 +671,7 @@ class EeroClient:
         response = await self._api.profiles.rename_profile(network_id, profile_id, name)
 
         self._invalidate_profile_cache(network_id, profile_id)
+        self._invalidate_profiles_list_cache(network_id)
 
         return response
 
@@ -693,6 +694,7 @@ class EeroClient:
         response = await self._api.profiles.delete_profile(network_id, profile_id)
 
         self._invalidate_profile_cache(network_id, profile_id)
+        self._invalidate_profiles_list_cache(network_id)
 
         return response
 


### PR DESCRIPTION
## Problem

`rename_profile` and `delete_profile` in `client.py` only call `_invalidate_profile_cache()` (single entry), but the cached profiles **list** still holds the old name (after rename) or the deleted entry (after delete) until TTL expires.

`create_profile` already correctly calls `_invalidate_profiles_list_cache()`.

Originally noted in [PR #42 review comment](https://github.com/fulviofreitas/eero-api/pull/42#issuecomment-4418394665).

## Fix

Add `_invalidate_profiles_list_cache(network_id)` to both `rename_profile` and `delete_profile`, matching what `create_profile` already does.

## Changes

- `src/eero/client.py`: +2 lines (one in each method)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>