### PR TITLE
feat(api): add data_usage endpoint

### DIFF
--- a/src/eero/api/__init__.py
+++ b/src/eero/api/__init__.py
@@ -10,6 +10,7 @@ from .auth import AuthAPI
 from .backup import BackupAPI
 from .blacklist import BlacklistAPI
 from .burst_reporters import BurstReportersAPI
+from .data_usage import DataUsageAPI
 from .devices import DevicesAPI
 from .diagnostics import DiagnosticsAPI
 from .dns import DnsAPI
@@ -72,6 +73,7 @@ class EeroAPI:
         self.forwards = ForwardsAPI(self.auth)
         self.transfer = TransferAPI(self.auth)
         self.burst_reporters = BurstReportersAPI(self.auth)
+        self.data_usage = DataUsageAPI(self.auth)
         self.ac_compat = ACCompatAPI(self.auth)
         self.ouicheck = OUICheckAPI(self.auth)
         self.password = PasswordAPI(self.auth)

--- a/src/eero/api/data_usage.py
+++ b/src/eero/api/data_usage.py
@@ -37,7 +37,11 @@ class DataUsageAPI(AuthenticatedAPI):
 
         Args:
             network_id: ID of the network to get usage from
-            payload: JSON payload to send with the GET request
+            payload: JSON payload to send with the GET request.
+                Note: The eero cloud API expects a JSON body on this GET
+                request (e.g., timezone, period filters), which is uncommon
+                but matches the behavior used by Home Assistant's eero
+                integration.
             resource: Optional resource type (e.g., "devices", "eeros")
 
         Returns:

--- a/src/eero/api/data_usage.py
+++ b/src/eero/api/data_usage.py
@@ -1,0 +1,60 @@
+"""Data Usage API for Eero.
+
+IMPORTANT: This module returns RAW responses from the Eero Cloud API.
+All data extraction, field mapping, and transformation must be done by downstream clients.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from ..const import API_ENDPOINT
+from ..exceptions import EeroAuthenticationException
+from .auth import AuthAPI
+from .base import AuthenticatedAPI
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DataUsageAPI(AuthenticatedAPI):
+    """Data Usage API for Eero.
+
+    All methods return raw, unmodified JSON responses from the Eero Cloud API.
+    Response format: {"meta": {...}, "data": {...}}
+    """
+
+    def __init__(self, auth_api: AuthAPI) -> None:
+        """Initialize the DataUsageAPI.
+
+        Args:
+            auth_api: Authentication API instance
+        """
+        super().__init__(auth_api, API_ENDPOINT)
+
+    async def get_data_usage(
+        self, network_id: str, payload: Dict[str, Any], resource: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Get data usage statistics - returns raw Eero API response.
+
+        Args:
+            network_id: ID of the network to get usage from
+            payload: JSON payload to send with the GET request
+            resource: Optional resource type (e.g., "devices", "eeros")
+
+        Returns:
+            Raw API response: {"meta": {...}, "data": {...}}
+
+        Raises:
+            EeroAuthenticationException: If not authenticated
+            EeroAPIException: If the API returns an error
+        """
+        auth_token = await self._auth_api.get_auth_token()
+        if not auth_token:
+            raise EeroAuthenticationException("Not authenticated")
+
+        path = f"networks/{network_id}/data_usage"
+        if resource:
+            path = f"{path}/{resource}"
+
+        _LOGGER.debug("Getting data usage for network %s (resource=%s)", network_id, resource)
+
+        return await self.get(path, auth_token=auth_token, json=payload)

--- a/src/eero/client.py
+++ b/src/eero/client.py
@@ -826,6 +826,18 @@ class EeroClient:
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.transfer.get_transfer_stats(network_id, device_id)
 
+    async def get_data_usage(
+        self,
+        network_id: Optional[str] = None,
+        payload: Optional[Dict[str, Any]] = None,
+        resource: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get data usage statistics - returns raw Eero API response."""
+        network_id = await self._ensure_network_id(network_id, auto_discover=False)
+        return await self._api.data_usage.get_data_usage(
+            network_id, payload or {}, resource
+        )
+
     async def get_burst_reporters(self, network_id: Optional[str] = None) -> Dict[str, Any]:
         """Get burst reporters - returns raw Eero API response."""
         network_id = await self._ensure_network_id(network_id, auto_discover=False)

--- a/src/eero/client.py
+++ b/src/eero/client.py
@@ -834,9 +834,7 @@ class EeroClient:
     ) -> Dict[str, Any]:
         """Get data usage statistics - returns raw Eero API response."""
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
-        return await self._api.data_usage.get_data_usage(
-            network_id, payload or {}, resource
-        )
+        return await self._api.data_usage.get_data_usage(network_id, payload or {}, resource)
 
     async def get_burst_reporters(self, network_id: Optional[str] = None) -> Dict[str, Any]:
         """Get burst reporters - returns raw Eero API response."""

--- a/tests/api/test_data_usage.py
+++ b/tests/api/test_data_usage.py
@@ -1,0 +1,104 @@
+"""Tests for DataUsageAPI module."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from eero.api.data_usage import DataUsageAPI
+from eero.exceptions import EeroAuthenticationException
+
+from .conftest import api_success_response, create_mock_response
+
+
+class TestDataUsageAPIInit:
+    """Tests for DataUsageAPI initialization."""
+
+    def test_init_with_auth_api(self, mock_session):
+        """Test initialization with AuthAPI."""
+        auth_api = MagicMock()
+        auth_api.session = mock_session
+        api = DataUsageAPI(auth_api)
+        assert api._auth_api is auth_api
+
+
+class TestDataUsageAPIGetDataUsage:
+    """Tests for get_data_usage method."""
+
+    @pytest.fixture
+    def data_usage_api(self, mock_session):
+        """Create a DataUsageAPI with mocked auth."""
+        auth_api = MagicMock()
+        auth_api.session = mock_session
+        auth_api.get_auth_token = AsyncMock(return_value="auth_token")
+        return DataUsageAPI(auth_api)
+
+    @pytest.mark.asyncio
+    async def test_get_data_usage_network_level(self, data_usage_api, mock_session):
+        """Test get_data_usage returns raw response for network-level usage."""
+        usage_data = {
+            "download": 1024000,
+            "upload": 512000,
+        }
+        mock_response = create_mock_response(200, api_success_response(usage_data))
+        mock_session.request.return_value = mock_response
+
+        payload = {"timezone": "America/New_York"}
+        result = await data_usage_api.get_data_usage("network_123", payload)
+
+        assert "meta" in result
+        assert "data" in result
+        # Verify the correct URL was called without resource suffix
+        call_args = mock_session.request.call_args
+        assert "networks/network_123/data_usage" in call_args[0][1]
+        assert call_args[1]["json"] == payload
+
+    @pytest.mark.asyncio
+    async def test_get_data_usage_devices_resource(self, data_usage_api, mock_session):
+        """Test get_data_usage with resource='devices'."""
+        usage_data = [{"device_id": "dev_1", "download": 100}]
+        mock_response = create_mock_response(200, api_success_response(usage_data))
+        mock_session.request.return_value = mock_response
+
+        payload = {"timezone": "America/New_York"}
+        result = await data_usage_api.get_data_usage("network_123", payload, resource="devices")
+
+        assert "meta" in result
+        assert "data" in result
+        call_args = mock_session.request.call_args
+        assert "networks/network_123/data_usage/devices" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_get_data_usage_eeros_resource(self, data_usage_api, mock_session):
+        """Test get_data_usage with resource='eeros'."""
+        usage_data = [{"eero_id": "eero_1", "download": 200}]
+        mock_response = create_mock_response(200, api_success_response(usage_data))
+        mock_session.request.return_value = mock_response
+
+        payload = {"timezone": "America/New_York"}
+        result = await data_usage_api.get_data_usage("network_123", payload, resource="eeros")
+
+        assert "meta" in result
+        assert "data" in result
+        call_args = mock_session.request.call_args
+        assert "networks/network_123/data_usage/eeros" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_get_data_usage_not_authenticated(self, data_usage_api):
+        """Test get_data_usage raises when not authenticated."""
+        data_usage_api._auth_api.get_auth_token = AsyncMock(return_value=None)
+
+        with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
+            await data_usage_api.get_data_usage("network_123", {})
+
+    @pytest.mark.asyncio
+    async def test_get_data_usage_sends_json_payload(self, data_usage_api, mock_session):
+        """Test that payload is sent as json kwarg on GET request."""
+        mock_response = create_mock_response(200, api_success_response({}))
+        mock_session.request.return_value = mock_response
+
+        payload = {"timezone": "UTC", "period": "day"}
+        await data_usage_api.get_data_usage("network_123", payload)
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[1]["json"] == payload


### PR DESCRIPTION
## Summary

- Add `DataUsageAPI` class (`src/eero/api/data_usage.py`) with `get_data_usage(network_id, payload, resource=None)` method calling GET `/networks/{id}/data_usage[/{resource}]`
- Wire into `EeroAPI` aggregator and `EeroClient` facade
- Add unit tests covering network-level, device-level (`resource="devices"`), and eero-level (`resource="eeros"`) usage queries

## Motivation

The eero-prometheus-exporter (fulviofreitas/eero-prometheus-exporter#54) currently works around missing `data_usage` support by reaching through private attrs (`client._api.auth.get(...)`). This adds first-class support so all downstream consumers can use it cleanly.

## Test plan

- [ ] CI passes (ruff, mypy, pytest)
- [ ] `tests/api/test_data_usage.py` covers: network-level, devices resource, eeros resource, auth failure, JSON payload verification