### PR TITLE
fix: address #109 (block_device), #110 (blacklist payload), #111 (priority)

### DIFF
--- a/src/eero/api/blacklist.py
+++ b/src/eero/api/blacklist.py
@@ -78,9 +78,7 @@ class BlacklistAPI(AuthenticatedAPI):
             json={"mac": mac},
         )
 
-    async def remove_from_blacklist(
-        self, network_id: str, mac_or_device_id: str
-    ) -> Dict[str, Any]:
+    async def remove_from_blacklist(self, network_id: str, mac_or_device_id: str) -> Dict[str, Any]:
         """Remove a device from the blacklist - returns raw Eero API response.
 
         Args:
@@ -101,9 +99,7 @@ class BlacklistAPI(AuthenticatedAPI):
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")
 
-        _LOGGER.debug(
-            "Removing %s from blacklist for network %s", mac_or_device_id, network_id
-        )
+        _LOGGER.debug("Removing %s from blacklist for network %s", mac_or_device_id, network_id)
         return await self.delete(
             f"networks/{network_id}/blacklist/{mac_or_device_id}",
             auth_token=auth_token,

--- a/src/eero/api/blacklist.py
+++ b/src/eero/api/blacklist.py
@@ -53,12 +53,12 @@ class BlacklistAPI(AuthenticatedAPI):
             auth_token=auth_token,
         )
 
-    async def add_to_blacklist(self, network_id: str, device_id: str) -> Dict[str, Any]:
+    async def add_to_blacklist(self, network_id: str, mac: str) -> Dict[str, Any]:
         """Add a device to the blacklist - returns raw Eero API response.
 
         Args:
             network_id: ID of the network
-            device_id: ID of the device to blacklist
+            mac: MAC address of the device to blacklist (colon-separated, e.g. "AA:BB:CC:11:22:33")
 
         Returns:
             Raw API response: {"meta": {...}, "data": {...}}
@@ -71,19 +71,24 @@ class BlacklistAPI(AuthenticatedAPI):
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")
 
-        _LOGGER.debug("Adding device %s to blacklist for network %s", device_id, network_id)
+        _LOGGER.debug("Adding MAC %s to blacklist for network %s", mac, network_id)
         return await self.post(
             f"networks/{network_id}/blacklist",
             auth_token=auth_token,
-            json={"device_id": device_id},
+            json={"mac": mac},
         )
 
-    async def remove_from_blacklist(self, network_id: str, device_id: str) -> Dict[str, Any]:
+    async def remove_from_blacklist(
+        self, network_id: str, mac_or_device_id: str
+    ) -> Dict[str, Any]:
         """Remove a device from the blacklist - returns raw Eero API response.
 
         Args:
             network_id: ID of the network
-            device_id: ID of the device to remove from blacklist
+            mac_or_device_id: MAC address or device ID to remove from the blacklist.
+                Live-verified: Eero's ``device_id`` for a blacklisted entry is the MAC
+                address with colons stripped (e.g. ``"AABBCC112233"``), so both the
+                raw MAC and the colon-stripped form are accepted as the URL segment.
 
         Returns:
             Raw API response: {"meta": {...}, "data": {...}}
@@ -96,8 +101,10 @@ class BlacklistAPI(AuthenticatedAPI):
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")
 
-        _LOGGER.debug("Removing device %s from blacklist for network %s", device_id, network_id)
+        _LOGGER.debug(
+            "Removing %s from blacklist for network %s", mac_or_device_id, network_id
+        )
         return await self.delete(
-            f"networks/{network_id}/blacklist/{device_id}",
+            f"networks/{network_id}/blacklist/{mac_or_device_id}",
             auth_token=auth_token,
         )

--- a/src/eero/api/devices.py
+++ b/src/eero/api/devices.py
@@ -5,6 +5,7 @@ All data extraction, field mapping, and transformation must be done by downstrea
 """
 
 import logging
+import warnings
 from typing import Any, Dict, Optional
 
 from ..const import API_ENDPOINT, DEVICE_UPDATE_ENDPOINT
@@ -209,6 +210,14 @@ class DevicesAPI(AuthenticatedAPI):
     ) -> Dict[str, Any]:
         """Set priority for a device (bandwidth prioritization) - returns raw Eero API response.
 
+        **Deprecated**: ``DevicesAPI.set_device_priority`` is a no-op. Eero's cloud
+        API no longer exposes device-level priority — there is no ``/priority`` or
+        ``/qos`` endpoint, and the ``prioritized`` field is absent from the device
+        object. Sending ``{prioritized: bool}`` via the device PUT returns 200 OK
+        but does not change any observable state (live-verified). This method is
+        scheduled for removal in v6.0.0. See
+        https://github.com/fulviofreitas/eero-api/issues/111
+
         Args:
             network_id: ID of the network
             device_id: ID of the device
@@ -222,6 +231,15 @@ class DevicesAPI(AuthenticatedAPI):
             EeroAuthenticationException: If not authenticated
             EeroAPIException: If the API returns an error
         """
+        warnings.warn(
+            "DevicesAPI.set_device_priority is a no-op — Eero's cloud API no longer exposes"
+            " device-level priority. The method returns 200 OK but does not change state."
+            " Scheduled for removal in v6.0.0."
+            " See https://github.com/fulviofreitas/eero-api/issues/111",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         auth_token = await self._auth_api.get_auth_token()
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")

--- a/src/eero/api/devices.py
+++ b/src/eero/api/devices.py
@@ -123,27 +123,51 @@ class DevicesAPI(AuthenticatedAPI):
         return await self._update_device(network_id, device_id, {"nickname": nickname}, auth_token)
 
     async def block_device(self, network_id: str, device_id: str, blocked: bool) -> Dict[str, Any]:
-        """Block or unblock a device - returns raw Eero API response.
+        """Block or unblock a device via the /blacklist endpoint.
+
+        The Eero cloud API does not honour a ``blocked`` field on the device
+        object — sending ``PUT /devices/{id}`` with ``{"blocked": true}`` is a
+        silent no-op (200 OK, state unchanged). Blocking is instead managed
+        through the ``/blacklist`` resource: POSTing ``{"mac": <mac>}`` adds the
+        device to the blacklist and DELETEing ``/blacklist/{device_id}`` removes
+        it. This method was rewritten to use that mechanism (issue #109).
+
+        Implementation detail: ``get_device`` is called first to resolve the
+        canonical MAC address (colon-separated, from ``data.mac``). The MAC is
+        then used as the payload for the POST. The DELETE continues to use the
+        caller-supplied ``device_id``, which Eero accepts as the URL segment
+        (live-verified: the blacklist entry's ``device_id`` is the MAC with
+        colons stripped).
 
         Args:
             network_id: ID of the network the device belongs to
-            device_id: ID of the device
-            blocked: Whether to block or unblock the device
+            device_id: ID of the device to block or unblock
+            blocked: True to add the device to the blacklist, False to remove it
 
         Returns:
             Raw API response: {"meta": {...}, "data": {...}}
 
         Raises:
             EeroAuthenticationException: If not authenticated
-            EeroAPIException: If the API returns an error
+            EeroAPIException: If the API returns an error or device lookup fails
         """
         auth_token = await self._auth_api.get_auth_token()
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")
 
-        _LOGGER.debug("%s device %s", "Blocking" if blocked else "Unblocking", device_id)
+        if blocked:
+            # Resolve the canonical MAC from the device object.
+            device_response = await self.get_device(network_id, device_id)
+            mac = device_response["data"]["mac"]
+            _LOGGER.debug(
+                "Blocking device %s (resolved MAC %s) via POST /blacklist", device_id, mac
+            )
+            url = f"{API_ENDPOINT}/networks/{network_id}/blacklist"
+            return await self.post(url, auth_token=auth_token, json={"mac": mac})
 
-        return await self._update_device(network_id, device_id, {"blocked": blocked}, auth_token)
+        _LOGGER.debug("Unblocking device %s via DELETE /blacklist/%s", device_id, device_id)
+        url = f"{API_ENDPOINT}/networks/{network_id}/blacklist/{device_id}"
+        return await self.delete(url, auth_token=auth_token)
 
     async def pause_device(self, network_id: str, device_id: str, paused: bool) -> Dict[str, Any]:
         """Pause or unpause internet access for a device - returns raw Eero API response.

--- a/src/eero/api/devices.py
+++ b/src/eero/api/devices.py
@@ -9,11 +9,21 @@ import warnings
 from typing import Any, Dict, Optional
 
 from ..const import API_ENDPOINT, DEVICE_UPDATE_ENDPOINT
-from ..exceptions import EeroAuthenticationException
+from ..exceptions import EeroAPIException, EeroAuthenticationException
 from .auth import AuthAPI
 from .base import AuthenticatedAPI
 
 _LOGGER = logging.getLogger(__name__)
+
+# Shared by DevicesAPI.set_device_priority and EeroClient.set_device_priority
+# (imported by client.py). Keep the message in one place so both surfaces stay
+# in sync when the removal target changes.
+PRIORITY_DEPRECATION_MSG = (
+    "set_device_priority is a no-op — Eero's cloud API no longer exposes"
+    " device-level priority. The method returns 200 OK but does not change state."
+    " Scheduled for removal in v6.0.0."
+    " See https://github.com/fulviofreitas/eero-api/issues/111"
+)
 
 
 class DevicesAPI(AuthenticatedAPI):
@@ -159,7 +169,12 @@ class DevicesAPI(AuthenticatedAPI):
         if blocked:
             # Resolve the canonical MAC from the device object.
             device_response = await self.get_device(network_id, device_id)
-            mac = device_response["data"]["mac"]
+            mac = (device_response or {}).get("data", {}).get("mac")
+            if not mac:
+                raise EeroAPIException(
+                    502,
+                    f"Device {device_id} response missing 'mac' field; cannot blacklist",
+                )
             _LOGGER.debug(
                 "Blocking device %s (resolved MAC %s) via POST /blacklist", device_id, mac
             )
@@ -232,10 +247,7 @@ class DevicesAPI(AuthenticatedAPI):
             EeroAPIException: If the API returns an error
         """
         warnings.warn(
-            "DevicesAPI.set_device_priority is a no-op — Eero's cloud API no longer exposes"
-            " device-level priority. The method returns 200 OK but does not change state."
-            " Scheduled for removal in v6.0.0."
-            " See https://github.com/fulviofreitas/eero-api/issues/111",
+            f"DevicesAPI.{PRIORITY_DEPRECATION_MSG}",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/eero/client.py
+++ b/src/eero/client.py
@@ -7,6 +7,7 @@ Response format: {"meta": {...}, "data": {...}}
 
 import logging
 import time
+import warnings
 from typing import Any, Dict, List, Optional
 
 from aiohttp import ClientSession
@@ -1148,7 +1149,33 @@ class EeroClient:
         duration_minutes: Optional[int] = None,
         network_id: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Set device priority - returns raw Eero API response."""
+        """Set device priority - returns raw Eero API response.
+
+        **Deprecated**: ``EeroClient.set_device_priority`` is a no-op. Eero's cloud
+        API no longer exposes device-level priority — there is no ``/priority`` or
+        ``/qos`` endpoint, and the ``prioritized`` field is absent from the device
+        object. Sending ``{prioritized: bool}`` via the device PUT returns 200 OK
+        but does not change any observable state (live-verified). This method is
+        scheduled for removal in v6.0.0. See
+        https://github.com/fulviofreitas/eero-api/issues/111
+
+        Args:
+            device_id: ID of the device
+            prioritized: True to prioritize, False to remove priority
+            duration_minutes: Duration in minutes (0 or None = indefinite)
+            network_id: ID of the network (uses preferred if None)
+
+        Returns:
+            Raw API response: {"meta": {...}, "data": {...}}
+        """
+        warnings.warn(
+            "EeroClient.set_device_priority is a no-op — Eero's cloud API no longer exposes"
+            " device-level priority. The method returns 200 OK but does not change state."
+            " Scheduled for removal in v6.0.0."
+            " See https://github.com/fulviofreitas/eero-api/issues/111",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         response = await self._api.devices.set_device_priority(
             network_id, device_id, prioritized, duration_minutes

--- a/src/eero/client.py
+++ b/src/eero/client.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 from aiohttp import ClientSession
 
 from .api import EeroAPI
+from .api.devices import PRIORITY_DEPRECATION_MSG
 from .exceptions import EeroException
 
 _LOGGER = logging.getLogger(__name__)
@@ -515,7 +516,14 @@ class EeroClient:
     async def block_device(
         self, device_id: str, blocked: bool, network_id: Optional[str] = None
     ) -> Dict[str, Any]:
-        """Block or unblock a device - returns raw Eero API response.
+        """Block or unblock a device via the /blacklist endpoint.
+
+        As of the fix for issue #109, blocking is routed through the
+        ``/networks/{id}/blacklist`` resource rather than the device PUT
+        (which the Eero cloud silently no-ops). When ``blocked=True`` this
+        performs a GET (to resolve the canonical MAC) followed by a POST,
+        so the call is no longer atomic — a transient error on the lookup
+        surfaces as an exception before any state change occurs.
 
         Args:
             device_id: ID of the device
@@ -1169,10 +1177,7 @@ class EeroClient:
             Raw API response: {"meta": {...}, "data": {...}}
         """
         warnings.warn(
-            "EeroClient.set_device_priority is a no-op — Eero's cloud API no longer exposes"
-            " device-level priority. The method returns 200 OK but does not change state."
-            " Scheduled for removal in v6.0.0."
-            " See https://github.com/fulviofreitas/eero-api/issues/111",
+            f"EeroClient.{PRIORITY_DEPRECATION_MSG}",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/api/test_blacklist.py
+++ b/tests/api/test_blacklist.py
@@ -70,9 +70,32 @@ class TestBlacklistAPIAddToBlacklist:
         mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
         mock_session.request.return_value = mock_response
 
-        result = await blacklist_api.add_to_blacklist("network_123", "device123")
+        result = await blacklist_api.add_to_blacklist("network_123", "AA:BB:CC:11:22:33")
 
         assert "meta" in result
+
+    @pytest.mark.asyncio
+    async def test_add_to_blacklist_sends_mac_payload(self, blacklist_api, mock_session):
+        """Test add_to_blacklist sends {mac: ...} payload (not device_id)."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await blacklist_api.add_to_blacklist("network_123", "AA:BB:CC:11:22:33")
+
+        call_args = mock_session.request.call_args
+        assert call_args.kwargs["json"] == {"mac": "AA:BB:CC:11:22:33"}
+
+    @pytest.mark.asyncio
+    async def test_add_to_blacklist_posts_to_correct_url(self, blacklist_api, mock_session):
+        """Test add_to_blacklist POSTs to networks/{id}/blacklist."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await blacklist_api.add_to_blacklist("network_123", "AA:BB:CC:11:22:33")
+
+        method, url = mock_session.request.call_args.args[:2]
+        assert method == "POST"
+        assert url.endswith("networks/network_123/blacklist")
 
     @pytest.mark.asyncio
     async def test_add_to_blacklist_not_authenticated(self, blacklist_api):
@@ -80,7 +103,7 @@ class TestBlacklistAPIAddToBlacklist:
         blacklist_api._auth_api.get_auth_token = AsyncMock(return_value=None)
 
         with pytest.raises(EeroAuthenticationException):
-            await blacklist_api.add_to_blacklist("network_123", "device123")
+            await blacklist_api.add_to_blacklist("network_123", "AA:BB:CC:11:22:33")
 
 
 class TestBlacklistAPIRemoveFromBlacklist:
@@ -100,6 +123,40 @@ class TestBlacklistAPIRemoveFromBlacklist:
         mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
         mock_session.request.return_value = mock_response
 
-        result = await blacklist_api.remove_from_blacklist("network_123", "device123")
+        result = await blacklist_api.remove_from_blacklist("network_123", "AA:BB:CC:11:22:33")
 
         assert "meta" in result
+
+    @pytest.mark.asyncio
+    async def test_remove_from_blacklist_deletes_correct_url(self, blacklist_api, mock_session):
+        """Test remove_from_blacklist DELETEs networks/{id}/blacklist/{mac_or_device_id}."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await blacklist_api.remove_from_blacklist("network_123", "AA:BB:CC:11:22:33")
+
+        method, url = mock_session.request.call_args.args[:2]
+        assert method == "DELETE"
+        assert url.endswith("networks/network_123/blacklist/AA:BB:CC:11:22:33")
+
+    @pytest.mark.asyncio
+    async def test_remove_from_blacklist_accepts_stripped_device_id(
+        self, blacklist_api, mock_session
+    ):
+        """Test remove_from_blacklist also accepts the colon-stripped device_id form."""
+        mock_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = mock_response
+
+        await blacklist_api.remove_from_blacklist("network_123", "AABBCC112233")
+
+        method, url = mock_session.request.call_args.args[:2]
+        assert method == "DELETE"
+        assert url.endswith("networks/network_123/blacklist/AABBCC112233")
+
+    @pytest.mark.asyncio
+    async def test_remove_from_blacklist_not_authenticated(self, blacklist_api):
+        """Test remove_from_blacklist raises when not authenticated."""
+        blacklist_api._auth_api.get_auth_token = AsyncMock(return_value=None)
+
+        with pytest.raises(EeroAuthenticationException):
+            await blacklist_api.remove_from_blacklist("network_123", "AA:BB:CC:11:22:33")

--- a/tests/api/test_devices.py
+++ b/tests/api/test_devices.py
@@ -349,7 +349,12 @@ class TestDevicesAPIPauseDevice:
 
 
 class TestDevicesAPIPriority:
-    """Tests for device priority management."""
+    """Tests for device priority management.
+
+    set_device_priority is deprecated (issue #111): Eero's cloud API no longer
+    exposes device-level priority. The method still performs a PUT and returns 200
+    OK, but the change has no observable effect on the network.
+    """
 
     @pytest.fixture
     def devices_api(self, mock_session):
@@ -360,15 +365,46 @@ class TestDevicesAPIPriority:
         return DevicesAPI(auth_api)
 
     @pytest.mark.asyncio
+    async def test_set_device_priority_emits_deprecation_warning(self, devices_api, mock_session):
+        """Test that calling set_device_priority raises DeprecationWarning (issue #111)."""
+        expected_response = {"meta": {"code": 200}, "data": {}}
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        with pytest.warns(DeprecationWarning, match="set_device_priority is a no-op"):
+            await devices_api.set_device_priority("network_123", "device_abc", prioritized=True)
+
+    @pytest.mark.asyncio
+    async def test_set_device_priority_warning_mentions_issue_url(self, devices_api, mock_session):
+        """Test the DeprecationWarning message includes the tracking issue URL."""
+        expected_response = {"meta": {"code": 200}, "data": {}}
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        with pytest.warns(DeprecationWarning, match="issues/111"):
+            await devices_api.set_device_priority("network_123", "device_abc", prioritized=True)
+
+    @pytest.mark.asyncio
+    async def test_set_device_priority_warning_mentions_v6_removal(self, devices_api, mock_session):
+        """Test the DeprecationWarning message mentions scheduled removal in v6.0.0."""
+        expected_response = {"meta": {"code": 200}, "data": {}}
+        mock_response = create_mock_response(200, expected_response)
+        mock_session.request.return_value = mock_response
+
+        with pytest.warns(DeprecationWarning, match="v6.0.0"):
+            await devices_api.set_device_priority("network_123", "device_abc", prioritized=True)
+
+    @pytest.mark.asyncio
     async def test_set_device_priority_returns_raw_response(self, devices_api, mock_session):
         """Test enabling device priority returns raw response."""
         expected_response = {"meta": {"code": 200}, "data": {}}
         mock_response = create_mock_response(200, expected_response)
         mock_session.request.return_value = mock_response
 
-        result = await devices_api.set_device_priority(
-            "network_123", "device_abc", prioritized=True
-        )
+        with pytest.warns(DeprecationWarning):
+            result = await devices_api.set_device_priority(
+                "network_123", "device_abc", prioritized=True
+            )
 
         assert "meta" in result
 
@@ -379,9 +415,10 @@ class TestDevicesAPIPriority:
         mock_response = create_mock_response(200, expected_response)
         mock_session.request.return_value = mock_response
 
-        result = await devices_api.set_device_priority(
-            "network_123", "device_abc", prioritized=True, duration_minutes=120
-        )
+        with pytest.warns(DeprecationWarning):
+            result = await devices_api.set_device_priority(
+                "network_123", "device_abc", prioritized=True, duration_minutes=120
+            )
 
         assert "meta" in result
         call_args = mock_session.request.call_args
@@ -391,12 +428,13 @@ class TestDevicesAPIPriority:
 
     @pytest.mark.asyncio
     async def test_set_device_priority_targets_v2_3_endpoint(self, devices_api, mock_session):
-        """Test the priority PUT targets the 2.3 endpoint (issue #102)."""
+        """Test the priority PUT still targets the 2.3 endpoint (issue #102)."""
         expected_response = {"meta": {"code": 200}, "data": {}}
         mock_response = create_mock_response(200, expected_response)
         mock_session.request.return_value = mock_response
 
-        await devices_api.set_device_priority("network_123", "device_abc", prioritized=True)
+        with pytest.warns(DeprecationWarning):
+            await devices_api.set_device_priority("network_123", "device_abc", prioritized=True)
 
         method, url = mock_session.request.call_args.args[:2]
         assert method == "PUT"

--- a/tests/api/test_devices.py
+++ b/tests/api/test_devices.py
@@ -159,7 +159,11 @@ class TestDevicesAPISetNickname:
 
 
 class TestDevicesAPIBlockDevice:
-    """Tests for block_device method."""
+    """Tests for block_device method (routes through /blacklist, not device PUT).
+
+    The Eero cloud API silently ignores PUT /devices/{id} with {"blocked": bool}.
+    Blocking is managed via POST/DELETE on /blacklist (issue #109).
+    """
 
     @pytest.fixture
     def devices_api(self, mock_session):
@@ -169,45 +173,119 @@ class TestDevicesAPIBlockDevice:
         auth_api.get_auth_token = AsyncMock(return_value="auth_token")
         return DevicesAPI(auth_api)
 
+    @pytest.fixture
+    def device_response(self):
+        """Raw API response returned by get_device, including colon-format MAC."""
+        return {
+            "meta": {"code": 200},
+            "data": {
+                "url": "/2.2/networks/network_123/devices/device_abc",
+                "mac": "AA:BB:CC:11:22:33",
+                "nickname": "Test Device",
+                "connected": True,
+                "blocked": False,
+            },
+        }
+
     @pytest.mark.asyncio
-    async def test_block_device_returns_raw_response(self, devices_api, mock_session):
-        """Test successful device blocking returns raw response."""
-        expected_response = {"meta": {"code": 200}, "data": {}}
-        mock_response = create_mock_response(200, expected_response)
-        mock_session.request.return_value = mock_response
+    async def test_block_device_fetches_device_first(
+        self, devices_api, mock_session, device_response
+    ):
+        """Test block_device calls get_device to resolve the MAC before POSTing."""
+        get_device_response = create_mock_response(200, device_response)
+        post_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.side_effect = [get_device_response, post_response]
+
+        await devices_api.block_device("network_123", "device_abc", True)
+
+        # First call must be GET /devices/{id}
+        first_call_method, first_call_url = mock_session.request.call_args_list[0].args[:2]
+        assert first_call_method == "GET"
+        assert "devices/device_abc" in first_call_url
+
+    @pytest.mark.asyncio
+    async def test_block_device_posts_mac_to_blacklist(
+        self, devices_api, mock_session, device_response
+    ):
+        """Test blocking POSTs the colon-format MAC to /blacklist (issue #109)."""
+        get_device_response = create_mock_response(200, device_response)
+        post_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.side_effect = [get_device_response, post_response]
 
         result = await devices_api.block_device("network_123", "device_abc", True)
 
         assert "meta" in result
+        second_call = mock_session.request.call_args_list[1]
+        method, url = second_call.args[:2]
+        assert method == "POST"
+        assert url.endswith("networks/network_123/blacklist")
+        assert second_call.kwargs["json"] == {"mac": "AA:BB:CC:11:22:33"}
 
     @pytest.mark.asyncio
-    async def test_block_device_sends_correct_payload(self, devices_api, mock_session):
-        """Test that correct payload is sent for blocking."""
-        expected_response = {"meta": {"code": 200}, "data": {}}
-        mock_response = create_mock_response(200, expected_response)
-        mock_session.request.return_value = mock_response
+    async def test_block_device_resolved_mac_is_colon_format(
+        self, devices_api, mock_session, device_response
+    ):
+        """Test that the MAC sent to /blacklist is in colon-separated format."""
+        get_device_response = create_mock_response(200, device_response)
+        post_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.side_effect = [get_device_response, post_response]
 
         await devices_api.block_device("network_123", "device_abc", True)
 
-        call_args = mock_session.request.call_args
-        assert call_args.kwargs["json"] == {"blocked": True}
+        second_call = mock_session.request.call_args_list[1]
+        sent_mac = second_call.kwargs["json"]["mac"]
+        # Colon-format: five colons, six two-char hex groups
+        assert sent_mac.count(":") == 5
+        assert sent_mac == "AA:BB:CC:11:22:33"
 
     @pytest.mark.asyncio
-    async def test_block_device_targets_v2_3_endpoint(self, devices_api, mock_session):
-        """Test the block PUT targets the 2.3 endpoint (issue #102).
+    async def test_unblock_device_deletes_from_blacklist(self, devices_api, mock_session):
+        """Test unblocking DELETEs /blacklist/{device_id} without fetching the device."""
+        delete_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = delete_response
 
-        On 2.2 the backend returns 200 OK but silently ignores the mutation, so
-        the write must go to 2.3 for the block to actually persist.
-        """
-        expected_response = {"meta": {"code": 200}, "data": {}}
-        mock_response = create_mock_response(200, expected_response)
-        mock_session.request.return_value = mock_response
+        result = await devices_api.block_device("network_123", "device_abc", False)
 
-        await devices_api.block_device("network_123", "device_abc", True)
-
+        assert "meta" in result
+        assert mock_session.request.call_count == 1
         method, url = mock_session.request.call_args.args[:2]
-        assert method == "PUT"
-        assert url == "https://api-user.e2ro.com/2.3/networks/network_123/devices/device_abc"
+        assert method == "DELETE"
+        assert url.endswith("networks/network_123/blacklist/device_abc")
+
+    @pytest.mark.asyncio
+    async def test_unblock_does_not_call_get_device(self, devices_api, mock_session):
+        """Test unblock path skips the get_device lookup (no MAC resolution needed)."""
+        delete_response = create_mock_response(200, {"meta": {"code": 200}, "data": {}})
+        mock_session.request.return_value = delete_response
+
+        await devices_api.block_device("network_123", "device_abc", False)
+
+        # Only one HTTP call: DELETE /blacklist/{device_id}
+        assert mock_session.request.call_count == 1
+        method, _ = mock_session.request.call_args.args[:2]
+        assert method == "DELETE"
+
+    @pytest.mark.asyncio
+    async def test_block_device_returns_raw_response(
+        self, devices_api, mock_session, device_response
+    ):
+        """Test block_device returns the raw API response from the blacklist POST."""
+        get_device_response = create_mock_response(200, device_response)
+        post_resp_data = {"meta": {"code": 200}, "data": {"blacklisted": True}}
+        post_response = create_mock_response(200, post_resp_data)
+        mock_session.request.side_effect = [get_device_response, post_response]
+
+        result = await devices_api.block_device("network_123", "device_abc", True)
+
+        assert result["meta"]["code"] == 200
+
+    @pytest.mark.asyncio
+    async def test_block_device_not_authenticated(self, devices_api):
+        """Test block_device raises when not authenticated."""
+        devices_api._auth_api.get_auth_token = AsyncMock(return_value=None)
+
+        with pytest.raises(EeroAuthenticationException):
+            await devices_api.block_device("network_123", "device_abc", True)
 
 
 class TestDevicesAPIPauseDevice:

--- a/tests/api/test_devices.py
+++ b/tests/api/test_devices.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from eero.api.devices import DevicesAPI
-from eero.exceptions import EeroAuthenticationException
+from eero.exceptions import EeroAPIException, EeroAuthenticationException
 
 from .conftest import api_success_response, create_mock_response
 
@@ -286,6 +286,29 @@ class TestDevicesAPIBlockDevice:
 
         with pytest.raises(EeroAuthenticationException):
             await devices_api.block_device("network_123", "device_abc", True)
+
+    @pytest.mark.asyncio
+    async def test_block_device_raises_when_device_response_missing_mac(
+        self, devices_api, mock_session
+    ):
+        """Test block(True) raises EeroAPIException(502) if get_device omits `mac`.
+
+        Guards the documented Raises contract: without a MAC we can't build the
+        blacklist POST payload, so we must fail loudly instead of silently
+        misbehaving. The blacklist POST must NOT be attempted in this case.
+        """
+        malformed = {"meta": {"code": 200}, "data": {"nickname": "no-mac-device"}}
+        get_device_response = create_mock_response(200, malformed)
+        mock_session.request.return_value = get_device_response
+
+        with pytest.raises(EeroAPIException) as exc_info:
+            await devices_api.block_device("network_123", "device_abc", True)
+
+        assert exc_info.value.status_code == 502
+        assert "missing 'mac' field" in str(exc_info.value)
+        # Only the get_device call happened; no POST to /blacklist was attempted.
+        assert mock_session.request.call_count == 1
+        assert mock_session.request.call_args.args[0] == "GET"
 
 
 class TestDevicesAPIPauseDevice:


### PR DESCRIPTION
Closes #109, closes #110, closes #111.

Follow-up to #108 — the three remaining "silent no-op" mutations that #108 explicitly deferred. Each has a different root cause than the /2.2 → /2.3 version drift #108 addressed, so they're bundled here rather than folded into that PR.

## Summary

| # | Method | What was broken | Fix |
|---|---|---|---|
| **#110** | `BlacklistAPI.add_to_blacklist` | Sent `{"device_id": …}`; Eero returned 400 `{"mac": "error.form.field.required"}` | Change signature to `add_to_blacklist(network_id, mac)`; send `{"mac": mac}` |
| **#109** | `DevicesAPI.block_device` | Sent `PUT /devices/{id}` `{"blocked": bool}`; device has no `blocked` field, so silently no-op | Rewrite to route through `/blacklist` (GET device to resolve canonical MAC → POST/DELETE on `/blacklist`) |
| **#111** | `set_device_priority` | Sent `{"prioritized": bool}`; device has no `prioritized` field; no `/priority` or `/qos` endpoint exists anywhere | Deprecate with `DeprecationWarning`; keep the 200-returning no-op for the deprecation window; scheduled removal in v6.0.0 |

## Live-verified against a real Eero account (device 3D printer, MAC `50:31:23:13:36:58`)

Before the fix (on `master` v5.0.12):
```
block_device(True)  → 200 OK, device.blacklisted stays False
```

After this branch:
```
baseline:      blacklisted=False
block_device(True)  → meta.code=200
after block:   blacklisted=True   ✅ persists
block_device(False) → meta.code=200
restored:      blacklisted=False  ✅
```

`set_device_priority` fires two `DeprecationWarning`s (once from each surface — `EeroClient.set_device_priority` and `DevicesAPI.set_device_priority`); both messages include the removal target (v6.0.0) and a link to #111.

## Live-established API facts (already documented in the commits and issue write-ups)

- `POST /2.2/networks/{id}/blacklist` with `{"mac": "AA:BB:CC:DD:EE:FF"}` is the correct add. Colon-format MAC as returned by `get_device().data.mac`.
- `DELETE /2.2/networks/{id}/blacklist/{device_id}` is the correct remove. Eero's `device_id` for a wireless device IS the MAC without colons, so the existing URL shape works — no change needed there (only the parameter name was clarified to `mac_or_device_id`).
- The `prioritized` / `priority_duration` field pair is not honoured by any known Eero endpoint. Confirmed via probing: `/priority`, `/qos`, `/devices/{id}/priority`, `/devices/{id}/qos` all 404.

## Downstream signature impact

Verified via ripgrep across `eeroctl`, `eero-ui`, `eero-prometheus-exporter`:
- `EeroClient.block_device(device_id, blocked, network_id)` — **signature unchanged**. eeroctl and eero-ui keep working. Behaviour becomes correct (was: silent no-op; now: actually blocks).
- `BlacklistAPI.add_to_blacklist` / `remove_from_blacklist` — parameter rename only. **Zero production callers** (tests only, updated in this PR).
- `set_device_priority` — behaviour unchanged (still a no-op returning 200) but now emits `DeprecationWarning`. eero-ui currently calls non-existent `prioritize_device` / `deprioritize_device` (already broken); this PR doesn't attempt to fix that.

## Test / lint status (local)

- `pytest tests/api/test_devices.py tests/api/test_blacklist.py -q` → 37 passed
- `black --check src/ tests/` → clean
- `ruff check src/ tests/` → clean
- Each commit passes `commitlint` (conventional-commits format)

## Commits

1. `0c7f57f` fix(blacklist): correct add_to_blacklist payload and rename remove parameter
2. `af15072` fix(devices): block_device now routes through /blacklist (issue #109)
3. `9f48d67` refactor(devices): deprecate set_device_priority (issue #111)
4. `8572adc` style: address code-review polish (black, defensive MAC guard, docstring mirror, dedup deprecation msg)

Not squashing on merge — each commit is scoped to one issue and reads clearly in `git blame`.

## Not addressed here (intentional)

- **`prioritize_device` / `deprioritize_device` on `EeroClient`** — eero-ui calls these; they don't exist. That's an eero-ui bug (it's calling methods that never existed in the SDK). Not fixed here since #111's decision was to deprecate the priority feature entirely.
- **Adding `mac` to `SecureLoggerAdapter`'s redaction set** — reviewer flagged this as a hardening opportunity. Filed as a separate follow-up if you want it; not blocking.

---

_Implementation by `python-pro` agent per detailed spec; code review by `security-engineer` agent; live-verification against real Eero account by the coordinator (me). Full session log available on request._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved device blocking and unblocking through the network blacklist.
  * Blacklist actions now support MAC addresses, including colon-stripped formats.

* **Deprecations**
  * Device priority management now displays a deprecation warning and is scheduled for removal in version 6.0.0.

* **Bug Fixes**
  * Device blocking now resolves and submits the correct MAC address, improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->