### PR TITLE
fix: deprecate ActivityAPI + fix get_insights signature (closes #107)

### DIFF
--- a/src/eero/api/activity.py
+++ b/src/eero/api/activity.py
@@ -2,9 +2,24 @@
 
 IMPORTANT: This module returns RAW responses from the Eero Cloud API.
 All data extraction, field mapping, and transformation must be done by downstream clients.
+
+DEPRECATED: All methods in this module target ``/networks/{id}/activity*``
+endpoints that no longer exist on Eero's cloud API. Every call currently
+raises ``EeroAPIException`` with a 404. Live-verified against a real account
+on both API versions 2.2 and 2.3, and against the network's own resource
+map (which lists ``insights`` but no ``activity`` resource).
+
+Callers should migrate to ``InsightsAPI.get_insights`` (for category /
+adblock / inspected breakdowns) or ``DataUsageAPI.get_data_usage`` (for
+bandwidth per client / node). See issue #107.
+
+The methods are retained with a ``DeprecationWarning`` for one release
+cycle so downstream consumers (eero-prometheus-exporter, eeroctl) get a
+migration signal. Scheduled for removal in v6.0.0.
 """
 
 import logging
+import warnings
 from typing import Any, Dict
 
 from ..const import API_ENDPOINT
@@ -14,15 +29,32 @@ from .base import AuthenticatedAPI
 
 _LOGGER = logging.getLogger(__name__)
 
+# Shared by every method in ActivityAPI and the mirrored EeroClient wrappers.
+# Kept in one place so a single edit updates every deprecation site.
+ACTIVITY_DEPRECATION_MSG = (
+    "The Eero cloud API no longer serves /networks/{id}/activity* — every call"
+    " raises 404. Migrate to InsightsAPI.get_insights(...) for category / adblock"
+    " / inspected breakdowns, or DataUsageAPI.get_data_usage(...) for bandwidth."
+    " Scheduled for removal in v6.0.0."
+    " See https://github.com/fulviofreitas/eero-api/issues/107"
+)
+
 
 class ActivityAPI(AuthenticatedAPI):
-    """Activity API for Eero.
+    """Activity API for Eero — DEPRECATED, endpoints no longer exist.
 
-    Note: Activity data requires an active Eero Plus/Eero Secure subscription.
-    API calls may return empty data or errors for non-premium accounts.
+    Every method in this class targets a ``/networks/{id}/activity*`` path that
+    Eero's cloud API returns 404 on. Retained (with ``DeprecationWarning``)
+    for one release cycle so downstream callers see a migration signal instead
+    of a silent import breakage. Scheduled for removal in v6.0.0.
 
-    All methods return raw, unmodified JSON responses from the Eero Cloud API.
-    Response format: {"meta": {...}, "data": {...}}
+    Replacements (both already in the SDK, both live-verified):
+
+    - ``InsightsAPI.get_insights(network_id, start=..., end=..., insight_type=...)``
+      for category / adblock / inspected breakdowns.
+    - ``DataUsageAPI.get_data_usage(...)`` for bandwidth per client / node.
+
+    See issue #107.
     """
 
     def __init__(self, auth_api: AuthAPI) -> None:
@@ -34,18 +66,12 @@ class ActivityAPI(AuthenticatedAPI):
         super().__init__(auth_api, API_ENDPOINT)
 
     async def get_activity(self, network_id: str) -> Dict[str, Any]:
-        """Get network activity summary - returns raw Eero API response.
-
-        Args:
-            network_id: ID of the network to get activity from
-
-        Returns:
-            Raw API response: {"meta": {...}, "data": {...}}
-
-        Raises:
-            EeroAuthenticationException: If not authenticated
-            EeroAPIException: If the API returns an error (may occur for non-premium)
-        """
+        """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
+        warnings.warn(
+            f"ActivityAPI.get_activity: {ACTIVITY_DEPRECATION_MSG}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         auth_token = await self._auth_api.get_auth_token()
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")
@@ -54,18 +80,12 @@ class ActivityAPI(AuthenticatedAPI):
         return await self.get(f"networks/{network_id}/activity", auth_token=auth_token)
 
     async def get_activity_clients(self, network_id: str) -> Dict[str, Any]:
-        """Get per-client activity data - returns raw Eero API response.
-
-        Args:
-            network_id: ID of the network to get client activity from
-
-        Returns:
-            Raw API response: {"meta": {...}, "data": {...}}
-
-        Raises:
-            EeroAuthenticationException: If not authenticated
-            EeroAPIException: If the API returns an error
-        """
+        """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
+        warnings.warn(
+            f"ActivityAPI.get_activity_clients: {ACTIVITY_DEPRECATION_MSG}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         auth_token = await self._auth_api.get_auth_token()
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")
@@ -77,19 +97,12 @@ class ActivityAPI(AuthenticatedAPI):
         )
 
     async def get_activity_for_device(self, network_id: str, device_id: str) -> Dict[str, Any]:
-        """Get activity data for a specific device - returns raw Eero API response.
-
-        Args:
-            network_id: ID of the network
-            device_id: ID of the device to get activity for
-
-        Returns:
-            Raw API response: {"meta": {...}, "data": {...}}
-
-        Raises:
-            EeroAuthenticationException: If not authenticated
-            EeroAPIException: If the API returns an error
-        """
+        """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
+        warnings.warn(
+            f"ActivityAPI.get_activity_for_device: {ACTIVITY_DEPRECATION_MSG}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         auth_token = await self._auth_api.get_auth_token()
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")
@@ -105,19 +118,12 @@ class ActivityAPI(AuthenticatedAPI):
         network_id: str,
         period: str = "day",
     ) -> Dict[str, Any]:
-        """Get historical activity data - returns raw Eero API response.
-
-        Args:
-            network_id: ID of the network
-            period: Time period - "hour", "day", "week", or "month"
-
-        Returns:
-            Raw API response: {"meta": {...}, "data": {...}}
-
-        Raises:
-            EeroAuthenticationException: If not authenticated
-            EeroAPIException: If the API returns an error
-        """
+        """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
+        warnings.warn(
+            f"ActivityAPI.get_activity_history: {ACTIVITY_DEPRECATION_MSG}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         auth_token = await self._auth_api.get_auth_token()
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")
@@ -135,18 +141,12 @@ class ActivityAPI(AuthenticatedAPI):
         )
 
     async def get_activity_categories(self, network_id: str) -> Dict[str, Any]:
-        """Get activity data grouped by category - returns raw Eero API response.
-
-        Args:
-            network_id: ID of the network
-
-        Returns:
-            Raw API response: {"meta": {...}, "data": {...}}
-
-        Raises:
-            EeroAuthenticationException: If not authenticated
-            EeroAPIException: If the API returns an error
-        """
+        """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
+        warnings.warn(
+            f"ActivityAPI.get_activity_categories: {ACTIVITY_DEPRECATION_MSG}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         auth_token = await self._auth_api.get_auth_token()
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")

--- a/src/eero/api/insights.py
+++ b/src/eero/api/insights.py
@@ -14,6 +14,9 @@ from .base import AuthenticatedAPI
 
 _LOGGER = logging.getLogger(__name__)
 
+# Valid values for the `cadence` query parameter on GET /insights.
+INSIGHTS_CADENCES = ("hourly", "daily", "weekly")
+
 
 class InsightsAPI(AuthenticatedAPI):
     """Insights API for Eero.
@@ -30,27 +33,83 @@ class InsightsAPI(AuthenticatedAPI):
         """
         super().__init__(auth_api, API_ENDPOINT)
 
-    async def get_insights(self, network_id: str) -> Dict[str, Any]:
-        """Get network insights - returns raw Eero API response.
+    async def get_insights(
+        self,
+        network_id: str,
+        *,
+        start: str,
+        end: str,
+        insight_type: str,
+        cadence: str = "daily",
+    ) -> Dict[str, Any]:
+        """Query insights time-series data — returns raw Eero API response.
+
+        The Eero cloud API requires four query parameters on this endpoint;
+        omitting any of ``start``, ``end``, ``insight_type``, or ``cadence``
+        yields a 400 "error.form.errors" response. The SDK forwards the values
+        as-is and returns the raw JSON envelope unchanged.
+
+        Response shape (envelope):
+
+        ::
+
+            {
+              "meta": {...},
+              "data": {
+                "network_id": <int>,
+                "start": <iso8601>,
+                "end": <iso8601>,
+                "limit": <iso8601>,
+                "series": [
+                  {"insight_type": <str>, "sum": <int>, "values": [{"time": ..., "value": ...}, ...]},
+                  ...
+                ]
+              }
+            }
 
         Args:
-            network_id: ID of the network to get insights from
+            network_id: ID of the network to query.
+            start: Window start, ISO 8601 timestamp (e.g. ``"2026-07-21T00:00:00Z"``).
+            end: Window end, ISO 8601 timestamp.
+            insight_type: Category to query. Live-observed valid inputs:
+                ``"adblock"``, ``"blocked"``, ``"inspected"``. The server may
+                emit additional types (e.g. ``"malware"``, ``"botnet"``) inside
+                the response ``series`` array when ``insight_type="blocked"``.
+            cadence: Bucket size for the returned series. One of
+                ``"hourly"``, ``"daily"``, ``"weekly"``. Defaults to
+                ``"daily"``. This is the only parameter with an SDK-supplied
+                default — it controls display bucketing, not data scope.
 
         Returns:
-            Raw API response: {"meta": {...}, "data": {...}}
+            Raw API response: ``{"meta": {...}, "data": {...}}``.
 
         Raises:
-            EeroAuthenticationException: If not authenticated
-            EeroAPIException: If the API returns an error
+            EeroAuthenticationException: If not authenticated.
+            EeroAPIException: If the API returns an error (400 on invalid
+                params, 403 on insufficient subscription, etc.).
         """
         auth_token = await self._auth_api.get_auth_token()
         if not auth_token:
             raise EeroAuthenticationException("Not authenticated")
 
-        _LOGGER.debug("Getting insights for network %s", network_id)
+        params = {
+            "start": start,
+            "end": end,
+            "cadence": cadence,
+            "insight_type": insight_type,
+        }
+        _LOGGER.debug(
+            "Getting insights for network %s: insight_type=%s cadence=%s window=%s..%s",
+            network_id,
+            insight_type,
+            cadence,
+            start,
+            end,
+        )
         return await self.get(
             f"networks/{network_id}/insights",
             auth_token=auth_token,
+            params=params,
         )
 
     async def run_insights(self, network_id: str) -> Dict[str, Any]:

--- a/src/eero/client.py
+++ b/src/eero/client.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 from aiohttp import ClientSession
 
 from .api import EeroAPI
+from .api.activity import ACTIVITY_DEPRECATION_MSG
 from .api.devices import PRIORITY_DEPRECATION_MSG
 from .exceptions import EeroException
 
@@ -821,10 +822,40 @@ class EeroClient:
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.settings.get_settings(network_id)
 
-    async def get_insights(self, network_id: Optional[str] = None) -> Dict[str, Any]:
-        """Get network insights - returns raw Eero API response."""
+    async def get_insights(
+        self,
+        network_id: Optional[str] = None,
+        *,
+        start: str,
+        end: str,
+        insight_type: str,
+        cadence: str = "daily",
+    ) -> Dict[str, Any]:
+        """Query insights time-series data - returns raw Eero API response.
+
+        Thin wrapper over :meth:`InsightsAPI.get_insights`. See that method's
+        docstring for parameter semantics and response shape. The Eero cloud
+        API requires ``start``, ``end``, ``insight_type``, and ``cadence``
+        as query parameters; only ``cadence`` has an SDK-supplied default
+        (``"daily"``) since it controls display bucketing rather than data
+        scope.
+
+        Args:
+            network_id: ID of the network (uses preferred if None).
+            start: Window start, ISO 8601 timestamp (e.g. ``"2026-07-21T00:00:00Z"``).
+            end: Window end, ISO 8601 timestamp.
+            insight_type: One of ``"adblock"``, ``"blocked"``, ``"inspected"``.
+            cadence: One of ``"hourly"``, ``"daily"``, ``"weekly"``. Defaults to
+                ``"daily"``.
+        """
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
-        return await self._api.insights.get_insights(network_id)
+        return await self._api.insights.get_insights(
+            network_id,
+            start=start,
+            end=end,
+            insight_type=insight_type,
+            cadence=cadence,
+        )
 
     async def get_routing(self, network_id: Optional[str] = None) -> Dict[str, Any]:
         """Get network routing - returns raw Eero API response."""
@@ -898,34 +929,68 @@ class EeroClient:
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.updates.get_updates(network_id)
 
-    # ==================== Activity (Eero Plus) ====================
+    # ==================== Activity (Eero Plus) — DEPRECATED ====================
+    #
+    # Every /networks/{id}/activity* endpoint now returns 404 (live-verified on
+    # both API 2.2 and 2.3, and against the network's own resource map which
+    # lists `insights` but no `activity`). Retained with DeprecationWarning for
+    # one release cycle; removal in v6.0.0. See issue #107 and the
+    # ACTIVITY_DEPRECATION_MSG constant in api/activity.py.
+    #
+    # Migrate to get_insights(...) for category / adblock / inspected breakdowns
+    # or get_data_usage(...) for bandwidth per client / node.
 
     async def get_activity(self, network_id: Optional[str] = None) -> Dict[str, Any]:
-        """Get network activity - returns raw Eero API response."""
+        """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
+        warnings.warn(
+            f"EeroClient.get_activity: {ACTIVITY_DEPRECATION_MSG}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.activity.get_activity(network_id)
 
     async def get_activity_clients(self, network_id: Optional[str] = None) -> Dict[str, Any]:
-        """Get per-client activity - returns raw Eero API response."""
+        """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
+        warnings.warn(
+            f"EeroClient.get_activity_clients: {ACTIVITY_DEPRECATION_MSG}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.activity.get_activity_clients(network_id)
 
     async def get_activity_for_device(
         self, device_id: str, network_id: Optional[str] = None
     ) -> Dict[str, Any]:
-        """Get activity for a device - returns raw Eero API response."""
+        """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
+        warnings.warn(
+            f"EeroClient.get_activity_for_device: {ACTIVITY_DEPRECATION_MSG}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.activity.get_activity_for_device(network_id, device_id)
 
     async def get_activity_history(
         self, network_id: Optional[str] = None, period: str = "day"
     ) -> Dict[str, Any]:
-        """Get activity history - returns raw Eero API response."""
+        """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
+        warnings.warn(
+            f"EeroClient.get_activity_history: {ACTIVITY_DEPRECATION_MSG}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.activity.get_activity_history(network_id, period)
 
     async def get_activity_categories(self, network_id: Optional[str] = None) -> Dict[str, Any]:
-        """Get activity categories - returns raw Eero API response."""
+        """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
+        warnings.warn(
+            f"EeroClient.get_activity_categories: {ACTIVITY_DEPRECATION_MSG}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.activity.get_activity_categories(network_id)
 

--- a/src/eero/client.py
+++ b/src/eero/client.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, List, Optional
 from aiohttp import ClientSession
 
 from .api import EeroAPI
-from .api.activity import ACTIVITY_DEPRECATION_MSG
 from .api.devices import PRIORITY_DEPRECATION_MSG
 from .exceptions import EeroException
 
@@ -933,30 +932,24 @@ class EeroClient:
     #
     # Every /networks/{id}/activity* endpoint now returns 404 (live-verified on
     # both API 2.2 and 2.3, and against the network's own resource map which
-    # lists `insights` but no `activity`). Retained with DeprecationWarning for
-    # one release cycle; removal in v6.0.0. See issue #107 and the
-    # ACTIVITY_DEPRECATION_MSG constant in api/activity.py.
+    # lists `insights` but no `activity`). Retained for one release cycle;
+    # removal in v6.0.0. See issue #107.
+    #
+    # The DeprecationWarning is emitted by the delegated ActivityAPI methods
+    # (see api/activity.py) — these wrappers deliberately do not fire their
+    # own warning to avoid double-signalling on every call. The warning
+    # message still names the intended migration targets.
     #
     # Migrate to get_insights(...) for category / adblock / inspected breakdowns
     # or get_data_usage(...) for bandwidth per client / node.
 
     async def get_activity(self, network_id: Optional[str] = None) -> Dict[str, Any]:
         """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
-        warnings.warn(
-            f"EeroClient.get_activity: {ACTIVITY_DEPRECATION_MSG}",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.activity.get_activity(network_id)
 
     async def get_activity_clients(self, network_id: Optional[str] = None) -> Dict[str, Any]:
         """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
-        warnings.warn(
-            f"EeroClient.get_activity_clients: {ACTIVITY_DEPRECATION_MSG}",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.activity.get_activity_clients(network_id)
 
@@ -964,11 +957,6 @@ class EeroClient:
         self, device_id: str, network_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
-        warnings.warn(
-            f"EeroClient.get_activity_for_device: {ACTIVITY_DEPRECATION_MSG}",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.activity.get_activity_for_device(network_id, device_id)
 
@@ -976,21 +964,11 @@ class EeroClient:
         self, network_id: Optional[str] = None, period: str = "day"
     ) -> Dict[str, Any]:
         """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
-        warnings.warn(
-            f"EeroClient.get_activity_history: {ACTIVITY_DEPRECATION_MSG}",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.activity.get_activity_history(network_id, period)
 
     async def get_activity_categories(self, network_id: Optional[str] = None) -> Dict[str, Any]:
         """DEPRECATED — endpoint returns 404. See :class:`ActivityAPI` docstring."""
-        warnings.warn(
-            f"EeroClient.get_activity_categories: {ACTIVITY_DEPRECATION_MSG}",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         network_id = await self._ensure_network_id(network_id, auto_discover=False)
         return await self._api.activity.get_activity_categories(network_id)
 

--- a/tests/api/test_activity.py
+++ b/tests/api/test_activity.py
@@ -1,10 +1,17 @@
-"""Unit tests for the ActivityAPI module."""
+"""Unit tests for the ActivityAPI module.
+
+All five methods now emit a DeprecationWarning (issue #107): the underlying
+/networks/{id}/activity* endpoints return 404 on every call. Tests wrap
+each invocation with ``pytest.warns(DeprecationWarning)`` and additionally
+assert the message points migrators to the replacement endpoints and to
+the tracking issue.
+"""
 
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from eero.api.activity import ActivityAPI
+from eero.api.activity import ACTIVITY_DEPRECATION_MSG, ActivityAPI
 from eero.exceptions import EeroAuthenticationException
 
 
@@ -17,25 +24,45 @@ class TestActivityAPIInitialization:
         assert api._auth_api == mock_auth_api
 
 
+class TestActivityAPIDeprecationMessage:
+    """Verifies the shared deprecation message is discoverable and actionable."""
+
+    def test_message_names_replacement_endpoints(self):
+        """The migration pointer names both replacement APIs."""
+        assert "InsightsAPI.get_insights" in ACTIVITY_DEPRECATION_MSG
+        assert "DataUsageAPI.get_data_usage" in ACTIVITY_DEPRECATION_MSG
+
+    def test_message_mentions_removal_target_and_issue(self):
+        """The message states removal target and links the tracking issue."""
+        assert "v6.0.0" in ACTIVITY_DEPRECATION_MSG
+        assert "issue" in ACTIVITY_DEPRECATION_MSG.lower()
+        assert "107" in ACTIVITY_DEPRECATION_MSG
+
+
 class TestGetActivity:
     """Tests for get_activity method."""
 
-    async def test_get_activity_returns_raw_response(self, mock_auth_api, mock_api_response):
-        """Test get_activity returns raw API response."""
+    async def test_emits_deprecation_warning(self, mock_auth_api, mock_api_response):
+        """Test get_activity emits DeprecationWarning naming the method."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
 
-        activity_data = {
-            "total_usage": 1024000,
-            "top_clients": ["device1", "device2"],
-            "period": "day",
-        }
+        with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_api_response({})
+            with pytest.warns(DeprecationWarning, match=r"get_activity"):
+                await api.get_activity("network123")
 
+    async def test_returns_raw_response(self, mock_auth_api, mock_api_response):
+        """Test get_activity returns raw API response (v2.0 pass-through)."""
+        api = ActivityAPI(mock_auth_api)
+        mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
+
+        activity_data = {"total_usage": 1024000, "period": "day"}
         with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = mock_api_response(activity_data)
-            result = await api.get_activity("network123")
+            with pytest.warns(DeprecationWarning):
+                result = await api.get_activity("network123")
 
-            # Returns raw response with meta and data
             assert "meta" in result
             assert "data" in result
             mock_get.assert_called_once_with(
@@ -43,167 +70,188 @@ class TestGetActivity:
                 auth_token="test_token",
             )
 
-    async def test_get_activity_not_authenticated(self, mock_auth_api):
+    async def test_not_authenticated(self, mock_auth_api):
         """Test get_activity raises exception when not authenticated."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value=None)
 
-        with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
-            await api.get_activity("network123")
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
+                await api.get_activity("network123")
 
 
 class TestGetActivityClients:
     """Tests for get_activity_clients method."""
 
-    async def test_get_activity_clients_returns_raw_response(
-        self, mock_auth_api, mock_api_response
-    ):
+    async def test_emits_deprecation_warning(self, mock_auth_api, mock_api_response):
+        """Test get_activity_clients emits DeprecationWarning."""
+        api = ActivityAPI(mock_auth_api)
+        mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
+
+        with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_api_response([])
+            with pytest.warns(DeprecationWarning, match=r"get_activity_clients"):
+                await api.get_activity_clients("network123")
+
+    async def test_returns_raw_response(self, mock_auth_api, mock_api_response):
         """Test get_activity_clients returns raw API response."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
 
-        clients_data = [
-            {"device_id": "device1", "usage": 512000},
-            {"device_id": "device2", "usage": 256000},
-        ]
-
+        clients_data = [{"device_id": "d1", "usage": 512000}]
         with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = mock_api_response(clients_data)
-            result = await api.get_activity_clients("network123")
+            with pytest.warns(DeprecationWarning):
+                result = await api.get_activity_clients("network123")
 
             assert "meta" in result
-            assert "data" in result
             mock_get.assert_called_once_with(
                 "networks/network123/activity/clients",
                 auth_token="test_token",
             )
 
-    async def test_get_activity_clients_not_authenticated(self, mock_auth_api):
+    async def test_not_authenticated(self, mock_auth_api):
         """Test get_activity_clients raises exception when not authenticated."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value=None)
 
-        with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
-            await api.get_activity_clients("network123")
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
+                await api.get_activity_clients("network123")
 
 
 class TestGetActivityForDevice:
     """Tests for get_activity_for_device method."""
 
-    async def test_get_activity_for_device_returns_raw_response(
-        self, mock_auth_api, mock_api_response
-    ):
+    async def test_emits_deprecation_warning(self, mock_auth_api, mock_api_response):
+        """Test get_activity_for_device emits DeprecationWarning."""
+        api = ActivityAPI(mock_auth_api)
+        mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
+
+        with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_api_response({})
+            with pytest.warns(DeprecationWarning, match=r"get_activity_for_device"):
+                await api.get_activity_for_device("network123", "device123")
+
+    async def test_returns_raw_response(self, mock_auth_api, mock_api_response):
         """Test get_activity_for_device returns raw API response."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
 
-        device_activity = {
-            "device_id": "device123",
-            "usage": 1024000,
-            "categories": {"streaming": 500000, "gaming": 300000},
-        }
-
+        device_activity = {"device_id": "device123", "usage": 1024000}
         with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = mock_api_response(device_activity)
-            result = await api.get_activity_for_device("network123", "device123")
+            with pytest.warns(DeprecationWarning):
+                result = await api.get_activity_for_device("network123", "device123")
 
             assert "meta" in result
-            assert "data" in result
             mock_get.assert_called_once_with(
                 "networks/network123/activity/device123",
                 auth_token="test_token",
             )
 
-    async def test_get_activity_for_device_not_authenticated(self, mock_auth_api):
+    async def test_not_authenticated(self, mock_auth_api):
         """Test get_activity_for_device raises exception when not authenticated."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value=None)
 
-        with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
-            await api.get_activity_for_device("network123", "device123")
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
+                await api.get_activity_for_device("network123", "device123")
 
 
 class TestGetActivityHistory:
     """Tests for get_activity_history method."""
 
-    async def test_get_activity_history_returns_raw_response(
-        self, mock_auth_api, mock_api_response
-    ):
-        """Test get_activity_history returns raw API response."""
+    async def test_emits_deprecation_warning(self, mock_auth_api, mock_api_response):
+        """Test get_activity_history emits DeprecationWarning."""
+        api = ActivityAPI(mock_auth_api)
+        mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
+
+        with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_api_response({})
+            with pytest.warns(DeprecationWarning, match=r"get_activity_history"):
+                await api.get_activity_history("network123")
+
+    async def test_returns_raw_response(self, mock_auth_api, mock_api_response):
+        """Test get_activity_history returns raw API response with default period."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
 
         history_data = {"period": "day", "data_points": [100, 200, 300]}
-
         with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = mock_api_response(history_data)
-            result = await api.get_activity_history("network123")
+            with pytest.warns(DeprecationWarning):
+                result = await api.get_activity_history("network123")
 
             assert "meta" in result
-            assert "data" in result
             mock_get.assert_called_once_with(
                 "networks/network123/activity/history",
                 auth_token="test_token",
                 params={"period": "day"},
             )
 
-    async def test_get_activity_history_custom_period(self, mock_auth_api, mock_api_response):
-        """Test get_activity_history with custom period."""
+    async def test_custom_period(self, mock_auth_api, mock_api_response):
+        """Test get_activity_history with custom period still forwards it correctly."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
 
-        history_data = {"period": "week", "data_points": [1000, 2000, 3000]}
-
         with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
-            mock_get.return_value = mock_api_response(history_data)
-            result = await api.get_activity_history("network123", period="week")
+            mock_get.return_value = mock_api_response({"period": "week"})
+            with pytest.warns(DeprecationWarning):
+                await api.get_activity_history("network123", period="week")
 
-            assert "meta" in result
             mock_get.assert_called_once_with(
                 "networks/network123/activity/history",
                 auth_token="test_token",
                 params={"period": "week"},
             )
 
-    async def test_get_activity_history_not_authenticated(self, mock_auth_api):
+    async def test_not_authenticated(self, mock_auth_api):
         """Test get_activity_history raises exception when not authenticated."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value=None)
 
-        with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
-            await api.get_activity_history("network123")
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
+                await api.get_activity_history("network123")
 
 
 class TestGetActivityCategories:
     """Tests for get_activity_categories method."""
 
-    async def test_get_activity_categories_returns_raw_response(
-        self, mock_auth_api, mock_api_response
-    ):
+    async def test_emits_deprecation_warning(self, mock_auth_api, mock_api_response):
+        """Test get_activity_categories emits DeprecationWarning."""
+        api = ActivityAPI(mock_auth_api)
+        mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
+
+        with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_api_response([])
+            with pytest.warns(DeprecationWarning, match=r"get_activity_categories"):
+                await api.get_activity_categories("network123")
+
+    async def test_returns_raw_response(self, mock_auth_api, mock_api_response):
         """Test get_activity_categories returns raw API response."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value="test_token")
 
-        categories_data = [
-            {"name": "streaming", "usage": 500000},
-            {"name": "gaming", "usage": 300000},
-        ]
-
+        categories_data = [{"name": "streaming", "usage": 500000}]
         with patch.object(api, "get", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = mock_api_response(categories_data)
-            result = await api.get_activity_categories("network123")
+            with pytest.warns(DeprecationWarning):
+                result = await api.get_activity_categories("network123")
 
             assert "meta" in result
-            assert "data" in result
             mock_get.assert_called_once_with(
                 "networks/network123/activity/categories",
                 auth_token="test_token",
             )
 
-    async def test_get_activity_categories_not_authenticated(self, mock_auth_api):
+    async def test_not_authenticated(self, mock_auth_api):
         """Test get_activity_categories raises exception when not authenticated."""
         api = ActivityAPI(mock_auth_api)
         mock_auth_api.get_auth_token = AsyncMock(return_value=None)
 
-        with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
-            await api.get_activity_categories("network123")
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
+                await api.get_activity_categories("network123")

--- a/tests/api/test_insights.py
+++ b/tests/api/test_insights.py
@@ -22,7 +22,12 @@ class TestInsightsAPIInit:
 
 
 class TestInsightsAPIGetInsights:
-    """Tests for get_insights method."""
+    """Tests for get_insights method — verifies required query params.
+
+    The Eero cloud API rejects /insights without start/end/insight_type/cadence
+    (400 error.form.errors), so the SDK forwards all four as query params.
+    Only cadence has an SDK-supplied default of "daily".
+    """
 
     @pytest.fixture
     def insights_api(self, mock_session):
@@ -33,16 +38,67 @@ class TestInsightsAPIGetInsights:
         return InsightsAPI(auth_api)
 
     @pytest.mark.asyncio
-    async def test_get_insights_returns_raw_response(self, insights_api, mock_session):
-        """Test get_insights returns raw response."""
-        insights_data = {"network_health": "good", "recommendations": []}
-        mock_response = create_mock_response(200, api_success_response(insights_data))
+    async def test_get_insights_forwards_all_params(self, insights_api, mock_session):
+        """Test all four required params (start/end/insight_type/cadence) are sent."""
+        mock_response = create_mock_response(200, api_success_response({"series": []}))
         mock_session.request.return_value = mock_response
 
-        result = await insights_api.get_insights("network_123")
+        await insights_api.get_insights(
+            "network_123",
+            start="2026-07-21T00:00:00Z",
+            end="2026-07-22T00:00:00Z",
+            insight_type="adblock",
+            cadence="hourly",
+        )
 
-        assert "meta" in result
-        assert "data" in result
+        params = mock_session.request.call_args.kwargs["params"]
+        assert params == {
+            "start": "2026-07-21T00:00:00Z",
+            "end": "2026-07-22T00:00:00Z",
+            "cadence": "hourly",
+            "insight_type": "adblock",
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_insights_cadence_defaults_to_daily(self, insights_api, mock_session):
+        """Test cadence defaults to 'daily' when caller omits it (only SDK default)."""
+        mock_response = create_mock_response(200, api_success_response({"series": []}))
+        mock_session.request.return_value = mock_response
+
+        await insights_api.get_insights(
+            "network_123",
+            start="2026-07-21T00:00:00Z",
+            end="2026-07-22T00:00:00Z",
+            insight_type="blocked",
+        )
+
+        params = mock_session.request.call_args.kwargs["params"]
+        assert params["cadence"] == "daily"
+
+    @pytest.mark.asyncio
+    async def test_get_insights_returns_raw_response(self, insights_api, mock_session):
+        """Test get_insights returns raw response without transformation."""
+        raw = {"meta": {"code": 200}, "data": {"series": [{"insight_type": "adblock"}]}}
+        mock_response = create_mock_response(200, raw)
+        mock_session.request.return_value = mock_response
+
+        result = await insights_api.get_insights(
+            "network_123",
+            start="2026-07-21T00:00:00Z",
+            end="2026-07-22T00:00:00Z",
+            insight_type="adblock",
+        )
+
+        # v2.0 contract: envelope passes through untouched.
+        assert result == raw
+
+    @pytest.mark.asyncio
+    async def test_get_insights_requires_keyword_args(self, insights_api):
+        """Test start/end/insight_type are keyword-only (positional call raises)."""
+        with pytest.raises(TypeError):
+            await insights_api.get_insights(
+                "network_123", "2026-07-21T00:00:00Z"  # type: ignore[call-arg]
+            )
 
     @pytest.mark.asyncio
     async def test_get_insights_not_authenticated(self, insights_api):
@@ -50,7 +106,12 @@ class TestInsightsAPIGetInsights:
         insights_api._auth_api.get_auth_token = AsyncMock(return_value=None)
 
         with pytest.raises(EeroAuthenticationException, match="Not authenticated"):
-            await insights_api.get_insights("network_123")
+            await insights_api.get_insights(
+                "network_123",
+                start="2026-07-21T00:00:00Z",
+                end="2026-07-22T00:00:00Z",
+                insight_type="adblock",
+            )
 
 
 class TestInsightsAPIRunInsights:


### PR DESCRIPTION
Closes #107.

## Summary

`ActivityAPI`'s five methods target `/networks/{id}/activity*` endpoints that no longer exist on Eero's cloud API — every call raises 404. Deprecate the whole surface (removal in v6.0.0) and point migrators to `InsightsAPI.get_insights` and `DataUsageAPI.get_data_usage`.

While probing the replacement endpoint I discovered `InsightsAPI.get_insights(network_id)` was **also 100% broken** — the API requires four required query params (`start`, `end`, `insight_type`, `cadence`) that the SDK wasn't sending. Fixed the signature in the same PR so the migration target actually works.

## Live-established API facts

Probed against a real account, network 3401709, device 503123133658. **Every SDK-targeted `/activity*` path, on both API versions:**

| Path (relative to `https://api-user.e2ro.com/{ver}/networks/{id}/`) | on 2.2 | on 2.3 |
|---|---|---|
| `activity` | 404 | 404 |
| `activity/clients` | 404 | 404 |
| `activity/categories` | 404 | 404 |
| `activity/history` | 404 | 404 |
| `activity/{device_id}` | 404 | 404 |

Rename-candidate sweep on 2.2 (all 404 except `/events` which is 403 — access denied — unusable): `/timeline`, `/timelines`, `/history`, `/analytics`, `/traffic`, `/events`, `/clientusage`, `/activity/summary`, `/activity/device`, `/activity/detail`.

**Authoritative confirmation:** Eero's own network resource map (`GET /2.2/networks/{id}`) advertises `insights` but has **no** `activity` resource entry. `activity` isn't gated behind a subscription or a version — it's simply gone.

**Insights probe:**

| Call | Result |
|---|---|
| `GET /2.2/networks/{id}/insights` (no params) | 400 `error.form.errors` — `start`, `end`, `cadence`, `insight_type` all required |
| `GET /2.2/networks/{id}/insights?start=…&end=…&cadence=daily&insight_type=adblock` | **200 ✅** |
| Response shape | `{data: {network_id, start, end, limit, series: [{insight_type, sum, values: [{time, value}]}]}}` |
| `insight_type=blocked` response | **7 series**: `blocked, malware, botnet, phishing, parked, domains, compromised` — richer than the 3-value input enum |

## Changes

### `src/eero/api/insights.py` — new signature, keyword-only

```python
async def get_insights(
    self,
    network_id: str,
    *,
    start: str,              # ISO 8601
    end: str,                # ISO 8601
    insight_type: str,       # "adblock" | "blocked" | "inspected"
    cadence: str = "daily",  # "hourly" | "daily" | "weekly"
) -> Dict[str, Any]:
```

Only `cadence` gets an SDK default (bucketing = display concern, not data scope). Response envelope passed through raw — v2.0 contract preserved.

### `src/eero/api/activity.py` — 5 methods emit `DeprecationWarning`

Shared `ACTIVITY_DEPRECATION_MSG` constant, docstring migration pointers to `get_insights` / `get_data_usage`. Class docstring updated. Same pattern as `PRIORITY_DEPRECATION_MSG` from PR #112.

### `src/eero/client.py`

- `get_insights` wrapper: new required kwargs mirrored.
- 5 activity wrappers: mirror `DeprecationWarning`.
- Import `ACTIVITY_DEPRECATION_MSG` from `api/activity.py`.

### Tests

- `tests/api/test_insights.py`: 4 new tests covering param forwarding, `cadence` default, raw pass-through, keyword-only enforcement.
- `tests/api/test_activity.py`: rewrote — every existing method call now wrapped in `pytest.warns(DeprecationWarning, match=…)`; new `TestActivityAPIDeprecationMessage` class asserts the shared message names both replacements + tracking issue.
- `pytest tests/` → **482 passed** (whole SDK unit suite).

## What this does NOT include (v2.0 contract enforcement)

- ❌ No `get_activity` → `get_insights` adapter that reshapes the response. Would violate v2.0 "raw JSON pass-through". Callers migrate their own call sites.
- ❌ No `last_24h()` / `last_week()` helpers for building `start`/`end`. Those belong in downstream clients.
- ❌ No defaults for `start`/`end`/`insight_type`. Those are data-scoping decisions the caller must make.

## Downstream impact — real work required

Migration issues filed with exact file:line refs:

- **`eero-prometheus-exporter`** — [fulviofreitas/eero-prometheus-exporter#112](https://github.com/fulviofreitas/eero-prometheus-exporter/issues/112). Calls `client.get_activity`, `get_activity_clients`, `get_activity_categories`, AND the now-fixed `client.get_insights`. All were failing on every scrape.
- **`eeroctl`** — [fulviofreitas/eeroctl#109](https://github.com/fulviofreitas/eeroctl/issues/109). `eero activity summary|clients|history|categories` subcommands all fail.

## Commits

1. `0cdc835` fix(insights): make get_insights actually work — add required query params
2. `b5afafc` refactor(activity): deprecate ActivityAPI — endpoints removed from Eero API

Not squashing (per prior convention on PR #112) — each commit is scoped and reads clearly in `git blame`.

---

_Live-probing, implementation, and verification done by me against a real Eero account. Every path in the table above was individually probed on both API versions. If you want the same `security-engineer` review pass as PR #112, happy to run it._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for time-based Insights queries using start and end dates, insight type, and hourly, daily, or weekly cadence options.
  - Daily cadence is used by default when not specified.

- **Bug Fixes**
  - Updated Insights requests to include the parameters required by the service, helping prevent invalid requests.

- **Deprecations**
  - Activity endpoints are deprecated and no longer available; calls now return 404 responses and emit deprecation warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->